### PR TITLE
docs: update exercises to match v0.4.0 release

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,4 +1,8 @@
 tasks:
+  - name: Install Tools
+    command: |
+      brew tap anchore/grype
+      brew install grype trivy
   - name: Display Help
     command: |
       gp open README.md

--- a/README.md
+++ b/README.md
@@ -2,11 +2,11 @@
 
 A Gitpod based playground to understand `bomctl`.
 
-### Use a Playground Environment
+## Use a Playground Environment
 
-[Launch the Playground](https://gitpod.io/?autostart=true#https://github.com/bomctl/bomctl-playground) in gitpod. 
+[Launch the Playground](https://gitpod.io/?autostart=true#https://github.com/bomctl/bomctl-playground) in gitpod.
 
-### Install Locally
+## Install Locally
 
 Follow one of the [installation methods](https://github.com/bomctl/bomctl?tab=readme-ov-file#installation).
 
@@ -26,6 +26,22 @@ The cache is located in one of these locations:
 
 Software Bill of Materials (SBOMs) are imported into the cache, manipulated, and then exported.
 
+### Format Agnostic
+
+Generating SBOMs for complex systems usually involves [multiple SBOM files](#multiple-sbom-files), and sometimes the
+format of SBOMs provided for sub-components is outside of a user's control. Internally, `bomctl` parses and stores
+SBOMs in a format-agnostic way. `bomctl` can import SBOMs in various formats and easily perform operations on them
+without having to first be converted, potentially losing information in the process. In addition, this allows for
+easy conversion of provided SBOMs and generation of SBOMs in all supported formats.
+
+For more information on which formats `bomctl` supports, run:
+
+```bash
+bomctl export --help
+```
+
+The supported formats and encodings are available in the help info.
+
 ### Multiple SBOM Files
 
 Rarely are systems represented by a single application, and therefore multiple components in a system need are probably going to be individual SBOMs. For example a helm chart deployment has several container images. Each container image is going to have its own SBOM.
@@ -41,7 +57,7 @@ bomctl has two commands for adding SBOMs to the cache
 - `bomctl fetch` will download SBOMs from different sources
 - `bomctl import` will import SBOM files or from stdin
 
-#### __Step 1__
+#### __Step 1: Fetch__
 
 Add SBOMs to cache:
 
@@ -49,15 +65,139 @@ Add SBOMs to cache:
 bomctl fetch https://raw.githubusercontent.com/bomctl/bomctl-playground/main/examples/bomctl-container-image/bomctl_bomctl_v0.3.0.cdx.json
 ```
 
-You will notice two important `bomctl` objectives in the command above. 
+You will notice two important `bomctl` objectives in the command above.
 
-1. `bomctl` is designed to handle collections or sets of SBOM documents. While only one url is listed in the coomand a second SBOM document. This happens because `bomctl` will recursively fetch any SBOMs that are external references of components. We believe this is a foundational concept for representing systems. 
+1. `bomctl` is designed to handle collections or sets of SBOM documents. While only one url is listed in the coomand a second SBOM document. This happens because `bomctl` will recursively fetch any SBOMs that are external references of components. We believe this is a foundational concept for representing systems.
 1. `bomctl` supports multiple SBOM formats. The first SBOM fetched is a cyclonedx 1.5 SBOM Document, the second externally referenced SBOM is an SPDX 2.3 SBOM Document.
 
-#### __Step 2__
+#### __Step 2: List__
 
 List SBOMs in cache:
 
 ``` bash
 bomctl list
+```
+
+### Import SBOMs from an SBOM generation tool or file
+
+#### __Step 1: Import from standard input__
+
+Using Trivy, Scan a remote image and pipe the output into bomctl
+
+```bash
+trivy image --format spdx-json chainguard/cosign:latest | bomctl import -
+```
+
+#### __Step 2: Import from file__
+
+``` bash
+bomctl import examples/bomctl_0.3.0_darwin_arm64.tar.gz.spdx.json
+```
+
+and/or
+
+``` bash
+bomctl import examples/bomctl_0.1.3_darwin_amd64.tar.gz.cdx.json
+```
+
+#### __Step 3: List__
+
+List SBOMs in cache:
+
+``` bash
+bomctl list
+```
+
+### Deliver SBOMs to the local file system and another tool
+
+#### __Step 1: Understanding Export Flags__
+
+``` bash
+bomctl export --help
+```
+
+You'll notice you have two flags that control how your document is exported:
+
+1. __Encoding__: Controls what encoding the resulting document will be, either json or xml. Default: `json`  
+    __Note__ that your format choice changes the encoding options.
+1. __Format__: Controls the format and format version. Default: `cyclonedx`  
+   __Note__ the generic `spdx` and `cyclonedx` format options. These will use the latest version of that format supported by `bomctl`.
+            There are more explicit format options for each format version if an older version is desired.
+
+#### __Step 2: Export to a file__
+
+Export the an SBOM to a local directory.
+
+We're going to export the cdx SBOM fetched in the first [exercise](#step-1-fetch). __If you haven't already, go back and fetch it.__
+
+``` bash
+bomctl export urn:uuid:f360ad8b-dc41-4256-afed-337a04dff5db -f spdx -o test.spdx.json
+```
+
+Note that we previously fetched a cdx SBOM and are exporting an SPDX SBOM.
+
+#### __Step 3: Export to another tool__
+
+Grype is a tool that can scan SBOMs for vulnerabilities and accepts them as input from stdin. bomctl can facilitate this.
+
+```bash
+bomctl export urn:uuid:f360ad8b-dc41-4256-afed-337a04dff5db | grype
+```
+
+### Merge SBOMs
+
+The `merge` command will merge two or more documents that exist in local storage. This will leave the original SBOMs unaltered in  
+the cache and will generate a new SBOM with the combined, deduplicated contents.
+
+More info regarding the `merge` command and merging strategy can be found in the help menu for the command:
+
+```bash
+bomctl merge --help
+```
+
+Next lets get some simple test boms in the db to illustrate how it works.
+
+``` bash
+bomctl import examples/bomctl_merge_A.cdx.json examples/bomctl_merge_B.cdx.json
+```
+
+View the imported SBOMs in the database:
+
+``` bash
+bomctl list
+```
+
+These are intentionally small, manageable SBOMs. So you can cat out the contents if you like, or simply open them in the editor to view.  
+To give the merged SBOM a specific name, add a `--name` or `-n` flag; otherwise a UUID will be generated and used as the name.  
+
+Once you're ready to merge:
+
+```bash
+bomctl merge urn:uuid:f360ad8b-dc41-4256-afed-337a04dff5db urn:uuid:3de02d44-f9c6-4a94-bf48-eb92730dc3b5
+```
+
+__Important:__ Look for the last line in the output, for a line that start with `INFO  merge: Adding merged document sbomID=`.  
+               Copy the string with `urn:uid` (Hint: it's everything after the `=`), __We'll need this in the next step__.
+
+Do another `list` to see the new third SBOM that has been generated, while both previous SBOMs are still available.
+
+``` bash
+bomctl list
+```
+
+Let's export the merged SBOM so we can see the before and after:  
+Replace the `<UUID>` with the uuid copied in the previous step.
+
+__Note:__ If you gave it a name in the previous step, use that instead of the UUID provided below.
+
+``` bash
+bomctl export <UUID> -f spdx -o merged-sbom.spdx.json
+```
+
+These SBOMs were originally CycloneDX, but we can export to SPDX if we want. Or if we want to inspect the merge more easily  
+(since we can use the original files as reference) we can also export as a CycloneDX SBOM. (remember the default export  
+format is CycloneDX so the `-f` isn't needed)
+
+``` bash
+bomctl export <UUID> -o merged-sbom.cdx.json
 ```

--- a/README.md
+++ b/README.md
@@ -173,7 +173,7 @@ To give the merged SBOM a specific name, add a `--name` or `-n` flag; otherwise 
 Once you're ready to merge:
 
 ```bash
-bomctl merge urn:uuid:f360ad8b-dc41-4256-afed-337a04dff5db urn:uuid:3de02d44-f9c6-4a94-bf48-eb92730dc3b5
+bomctl merge urn:uuid:0cd5c64f-318a-40cd-a2a9-a93301beff5d urn:uuid:3de02d44-f9c6-4a94-bf48-eb92730dc3b5
 ```
 
 __Important:__ Look for the last line in the output, for a line that start with `INFO  merge: Adding merged document sbomID=`.  

--- a/examples/bomctl_0.1.3_darwin_amd64.tar.gz.cdx.json
+++ b/examples/bomctl_0.1.3_darwin_amd64.tar.gz.cdx.json
@@ -1,0 +1,3934 @@
+{
+    "$schema": "http://cyclonedx.org/schema/bom-1.5.schema.json",
+    "bomFormat": "CycloneDX",
+    "specVersion": "1.5",
+    "serialNumber": "urn:uuid:22ff1e59-cd6e-485a-83d1-24e64f87c5db",
+    "version": 1,
+    "metadata": {
+        "timestamp": "2024-04-20T20:08:27Z",
+        "tools": {
+            "components": [
+                {
+                    "type": "application",
+                    "author": "anchore",
+                    "name": "syft",
+                    "version": "0.103.1"
+                }
+            ]
+        },
+        "component": {
+            "bom-ref": "a7c5855eb24f0a8a",
+            "type": "file",
+            "name": "bomctl_0.1.3_darwin_amd64.tar.gz",
+            "version": "sha256:67376cf6545159a6d36c3c41c8b51fa45597ca52d90c88ad14a09388c2653ac7"
+        }
+    },
+    "components": [
+        {
+            "bom-ref": "pkg:golang/dario.cat/mergo@v1.0.0?package-id=25a9b39edd1f441d",
+            "type": "library",
+            "name": "dario.cat/mergo",
+            "version": "v1.0.0",
+            "purl": "pkg:golang/dario.cat/mergo@v1.0.0",
+            "properties": [
+                {
+                    "name": "syft:package:foundBy",
+                    "value": "go-module-binary-cataloger"
+                },
+                {
+                    "name": "syft:package:language",
+                    "value": "go"
+                },
+                {
+                    "name": "syft:package:type",
+                    "value": "go-module"
+                },
+                {
+                    "name": "syft:package:metadataType",
+                    "value": "go-module-buildinfo-entry"
+                },
+                {
+                    "name": "syft:location:0:path",
+                    "value": "bomctl"
+                },
+                {
+                    "name": "syft:metadata:architecture",
+                    "value": "amd64"
+                },
+                {
+                    "name": "syft:metadata:goCompiledVersion",
+                    "value": "go1.22.2"
+                },
+                {
+                    "name": "syft:metadata:h1Digest",
+                    "value": "h1:AGCNq9Evsj31mOgNPcLyXc+4PNABt905YmuqPYYpBWk="
+                },
+                {
+                    "name": "syft:metadata:mainModule",
+                    "value": "github.com/bomctl/bomctl"
+                }
+            ]
+        },
+        {
+            "bom-ref": "pkg:golang/github.com/cyclonedx/cyclonedx-go@v0.8.0?package-id=f9ac75d72ffe18b4",
+            "type": "library",
+            "name": "github.com/CycloneDX/cyclonedx-go",
+            "version": "v0.8.0",
+            "cpe": "cpe:2.3:a:CycloneDX:cyclonedx-go:v0.8.0:*:*:*:*:*:*:*",
+            "purl": "pkg:golang/github.com/CycloneDX/cyclonedx-go@v0.8.0",
+            "properties": [
+                {
+                    "name": "syft:package:foundBy",
+                    "value": "go-module-binary-cataloger"
+                },
+                {
+                    "name": "syft:package:language",
+                    "value": "go"
+                },
+                {
+                    "name": "syft:package:type",
+                    "value": "go-module"
+                },
+                {
+                    "name": "syft:package:metadataType",
+                    "value": "go-module-buildinfo-entry"
+                },
+                {
+                    "name": "syft:cpe23",
+                    "value": "cpe:2.3:a:CycloneDX:cyclonedx_go:v0.8.0:*:*:*:*:*:*:*"
+                },
+                {
+                    "name": "syft:location:0:path",
+                    "value": "bomctl"
+                },
+                {
+                    "name": "syft:metadata:architecture",
+                    "value": "amd64"
+                },
+                {
+                    "name": "syft:metadata:goCompiledVersion",
+                    "value": "go1.22.2"
+                },
+                {
+                    "name": "syft:metadata:h1Digest",
+                    "value": "h1:FyWVj6x6hoJrui5uRQdYZcSievw3Z32Z88uYzG/0D6M="
+                },
+                {
+                    "name": "syft:metadata:mainModule",
+                    "value": "github.com/bomctl/bomctl"
+                }
+            ]
+        },
+        {
+            "bom-ref": "pkg:golang/github.com/protonmail/go-crypto@v0.0.0-20230828082145-3c4c8a2d2371?package-id=3badb33cc0d40238",
+            "type": "library",
+            "name": "github.com/ProtonMail/go-crypto",
+            "version": "v0.0.0-20230828082145-3c4c8a2d2371",
+            "cpe": "cpe:2.3:a:ProtonMail:go-crypto:v0.0.0-20230828082145-3c4c8a2d2371:*:*:*:*:*:*:*",
+            "purl": "pkg:golang/github.com/ProtonMail/go-crypto@v0.0.0-20230828082145-3c4c8a2d2371",
+            "properties": [
+                {
+                    "name": "syft:package:foundBy",
+                    "value": "go-module-binary-cataloger"
+                },
+                {
+                    "name": "syft:package:language",
+                    "value": "go"
+                },
+                {
+                    "name": "syft:package:type",
+                    "value": "go-module"
+                },
+                {
+                    "name": "syft:package:metadataType",
+                    "value": "go-module-buildinfo-entry"
+                },
+                {
+                    "name": "syft:cpe23",
+                    "value": "cpe:2.3:a:ProtonMail:go_crypto:v0.0.0-20230828082145-3c4c8a2d2371:*:*:*:*:*:*:*"
+                },
+                {
+                    "name": "syft:location:0:path",
+                    "value": "bomctl"
+                },
+                {
+                    "name": "syft:metadata:architecture",
+                    "value": "amd64"
+                },
+                {
+                    "name": "syft:metadata:goCompiledVersion",
+                    "value": "go1.22.2"
+                },
+                {
+                    "name": "syft:metadata:h1Digest",
+                    "value": "h1:kkhsdkhsCvIsutKu5zLMgWtgh9YxGCNAw8Ad8hjwfYg="
+                },
+                {
+                    "name": "syft:metadata:mainModule",
+                    "value": "github.com/bomctl/bomctl"
+                }
+            ]
+        },
+        {
+            "bom-ref": "pkg:golang/github.com/anchore/go-struct-converter@v0.0.0-20230627203149-c72ef8859ca9?package-id=2c6d86b48f16828c",
+            "type": "library",
+            "name": "github.com/anchore/go-struct-converter",
+            "version": "v0.0.0-20230627203149-c72ef8859ca9",
+            "cpe": "cpe:2.3:a:anchore:go-struct-converter:v0.0.0-20230627203149-c72ef8859ca9:*:*:*:*:*:*:*",
+            "purl": "pkg:golang/github.com/anchore/go-struct-converter@v0.0.0-20230627203149-c72ef8859ca9",
+            "properties": [
+                {
+                    "name": "syft:package:foundBy",
+                    "value": "go-module-binary-cataloger"
+                },
+                {
+                    "name": "syft:package:language",
+                    "value": "go"
+                },
+                {
+                    "name": "syft:package:type",
+                    "value": "go-module"
+                },
+                {
+                    "name": "syft:package:metadataType",
+                    "value": "go-module-buildinfo-entry"
+                },
+                {
+                    "name": "syft:cpe23",
+                    "value": "cpe:2.3:a:anchore:go_struct_converter:v0.0.0-20230627203149-c72ef8859ca9:*:*:*:*:*:*:*"
+                },
+                {
+                    "name": "syft:location:0:path",
+                    "value": "bomctl"
+                },
+                {
+                    "name": "syft:metadata:architecture",
+                    "value": "amd64"
+                },
+                {
+                    "name": "syft:metadata:goCompiledVersion",
+                    "value": "go1.22.2"
+                },
+                {
+                    "name": "syft:metadata:h1Digest",
+                    "value": "h1:6COpXWpHbhWM1wgcQN95TdsmrLTba8KQfPgImBXzkjA="
+                },
+                {
+                    "name": "syft:metadata:mainModule",
+                    "value": "github.com/bomctl/bomctl"
+                }
+            ]
+        },
+        {
+            "bom-ref": "pkg:golang/github.com/aymanbagabas/go-osc52@v2.0.1?package-id=2715ce388cde630d#v2",
+            "type": "library",
+            "name": "github.com/aymanbagabas/go-osc52/v2",
+            "version": "v2.0.1",
+            "cpe": "cpe:2.3:a:aymanbagabas:go-osc52\\/v2:v2.0.1:*:*:*:*:*:*:*",
+            "purl": "pkg:golang/github.com/aymanbagabas/go-osc52@v2.0.1#v2",
+            "properties": [
+                {
+                    "name": "syft:package:foundBy",
+                    "value": "go-module-binary-cataloger"
+                },
+                {
+                    "name": "syft:package:language",
+                    "value": "go"
+                },
+                {
+                    "name": "syft:package:type",
+                    "value": "go-module"
+                },
+                {
+                    "name": "syft:package:metadataType",
+                    "value": "go-module-buildinfo-entry"
+                },
+                {
+                    "name": "syft:cpe23",
+                    "value": "cpe:2.3:a:aymanbagabas:go_osc52\\/v2:v2.0.1:*:*:*:*:*:*:*"
+                },
+                {
+                    "name": "syft:location:0:path",
+                    "value": "bomctl"
+                },
+                {
+                    "name": "syft:metadata:architecture",
+                    "value": "amd64"
+                },
+                {
+                    "name": "syft:metadata:goCompiledVersion",
+                    "value": "go1.22.2"
+                },
+                {
+                    "name": "syft:metadata:h1Digest",
+                    "value": "h1:HwpRHbFMcZLEVr42D4p7XBqjyuxQH5SMiErDT4WkJ2k="
+                },
+                {
+                    "name": "syft:metadata:mainModule",
+                    "value": "github.com/bomctl/bomctl"
+                }
+            ]
+        },
+        {
+            "bom-ref": "pkg:golang/github.com/bom-squad/protobom@v0.3.1-0.20240301165935-631d732bfcce?package-id=bdfd02b435c80a79",
+            "type": "library",
+            "name": "github.com/bom-squad/protobom",
+            "version": "v0.3.1-0.20240301165935-631d732bfcce",
+            "cpe": "cpe:2.3:a:bom-squad:protobom:v0.3.1-0.20240301165935-631d732bfcce:*:*:*:*:*:*:*",
+            "purl": "pkg:golang/github.com/bom-squad/protobom@v0.3.1-0.20240301165935-631d732bfcce",
+            "properties": [
+                {
+                    "name": "syft:package:foundBy",
+                    "value": "go-module-binary-cataloger"
+                },
+                {
+                    "name": "syft:package:language",
+                    "value": "go"
+                },
+                {
+                    "name": "syft:package:type",
+                    "value": "go-module"
+                },
+                {
+                    "name": "syft:package:metadataType",
+                    "value": "go-module-buildinfo-entry"
+                },
+                {
+                    "name": "syft:cpe23",
+                    "value": "cpe:2.3:a:bom_squad:protobom:v0.3.1-0.20240301165935-631d732bfcce:*:*:*:*:*:*:*"
+                },
+                {
+                    "name": "syft:cpe23",
+                    "value": "cpe:2.3:a:bom:protobom:v0.3.1-0.20240301165935-631d732bfcce:*:*:*:*:*:*:*"
+                },
+                {
+                    "name": "syft:location:0:path",
+                    "value": "bomctl"
+                },
+                {
+                    "name": "syft:metadata:architecture",
+                    "value": "amd64"
+                },
+                {
+                    "name": "syft:metadata:goCompiledVersion",
+                    "value": "go1.22.2"
+                },
+                {
+                    "name": "syft:metadata:h1Digest",
+                    "value": "h1:zs25QPwd1aEfBL3h4zhsx+BQ5e2bgC5tVp2aS53zbUs="
+                },
+                {
+                    "name": "syft:metadata:mainModule",
+                    "value": "github.com/bomctl/bomctl"
+                }
+            ]
+        },
+        {
+            "bom-ref": "pkg:golang/github.com/bomctl/bomctl@v0.1.3?package-id=4f03fa2257504412",
+            "type": "library",
+            "name": "github.com/bomctl/bomctl",
+            "version": "v0.1.3",
+            "cpe": "cpe:2.3:a:bomctl:bomctl:v0.1.3:*:*:*:*:*:*:*",
+            "purl": "pkg:golang/github.com/bomctl/bomctl@v0.1.3",
+            "properties": [
+                {
+                    "name": "syft:package:foundBy",
+                    "value": "go-module-binary-cataloger"
+                },
+                {
+                    "name": "syft:package:language",
+                    "value": "go"
+                },
+                {
+                    "name": "syft:package:type",
+                    "value": "go-module"
+                },
+                {
+                    "name": "syft:package:metadataType",
+                    "value": "go-module-buildinfo-entry"
+                },
+                {
+                    "name": "syft:location:0:path",
+                    "value": "bomctl"
+                },
+                {
+                    "name": "syft:metadata:architecture",
+                    "value": "amd64"
+                },
+                {
+                    "name": "syft:metadata:goBuildSettings:-buildmode",
+                    "value": "exe"
+                },
+                {
+                    "name": "syft:metadata:goBuildSettings:-compiler",
+                    "value": "gc"
+                },
+                {
+                    "name": "syft:metadata:goBuildSettings:-trimpath",
+                    "value": "true"
+                },
+                {
+                    "name": "syft:metadata:goBuildSettings:CGO_ENABLED",
+                    "value": "0"
+                },
+                {
+                    "name": "syft:metadata:goBuildSettings:GOAMD64",
+                    "value": "v1"
+                },
+                {
+                    "name": "syft:metadata:goBuildSettings:GOARCH",
+                    "value": "amd64"
+                },
+                {
+                    "name": "syft:metadata:goBuildSettings:GOOS",
+                    "value": "darwin"
+                },
+                {
+                    "name": "syft:metadata:goCompiledVersion",
+                    "value": "go1.22.2"
+                },
+                {
+                    "name": "syft:metadata:h1Digest",
+                    "value": "h1:Ug/2enSgM9WWT92VO68/2OGG19T2A2e773eOvruDOF4="
+                },
+                {
+                    "name": "syft:metadata:mainModule",
+                    "value": "github.com/bomctl/bomctl"
+                }
+            ]
+        },
+        {
+            "bom-ref": "pkg:golang/github.com/charmbracelet/lipgloss@v0.9.1?package-id=0df436c88c291a28",
+            "type": "library",
+            "name": "github.com/charmbracelet/lipgloss",
+            "version": "v0.9.1",
+            "cpe": "cpe:2.3:a:charmbracelet:lipgloss:v0.9.1:*:*:*:*:*:*:*",
+            "purl": "pkg:golang/github.com/charmbracelet/lipgloss@v0.9.1",
+            "properties": [
+                {
+                    "name": "syft:package:foundBy",
+                    "value": "go-module-binary-cataloger"
+                },
+                {
+                    "name": "syft:package:language",
+                    "value": "go"
+                },
+                {
+                    "name": "syft:package:type",
+                    "value": "go-module"
+                },
+                {
+                    "name": "syft:package:metadataType",
+                    "value": "go-module-buildinfo-entry"
+                },
+                {
+                    "name": "syft:location:0:path",
+                    "value": "bomctl"
+                },
+                {
+                    "name": "syft:metadata:architecture",
+                    "value": "amd64"
+                },
+                {
+                    "name": "syft:metadata:goCompiledVersion",
+                    "value": "go1.22.2"
+                },
+                {
+                    "name": "syft:metadata:h1Digest",
+                    "value": "h1:PNyd3jvaJbg4jRHKWXnCj1akQm4rh8dbEzN1p/u1KWg="
+                },
+                {
+                    "name": "syft:metadata:mainModule",
+                    "value": "github.com/bomctl/bomctl"
+                }
+            ]
+        },
+        {
+            "bom-ref": "pkg:golang/github.com/charmbracelet/log@v0.3.1?package-id=fd5ef4ffd138d9a3",
+            "type": "library",
+            "name": "github.com/charmbracelet/log",
+            "version": "v0.3.1",
+            "cpe": "cpe:2.3:a:charmbracelet:log:v0.3.1:*:*:*:*:*:*:*",
+            "purl": "pkg:golang/github.com/charmbracelet/log@v0.3.1",
+            "properties": [
+                {
+                    "name": "syft:package:foundBy",
+                    "value": "go-module-binary-cataloger"
+                },
+                {
+                    "name": "syft:package:language",
+                    "value": "go"
+                },
+                {
+                    "name": "syft:package:type",
+                    "value": "go-module"
+                },
+                {
+                    "name": "syft:package:metadataType",
+                    "value": "go-module-buildinfo-entry"
+                },
+                {
+                    "name": "syft:location:0:path",
+                    "value": "bomctl"
+                },
+                {
+                    "name": "syft:metadata:architecture",
+                    "value": "amd64"
+                },
+                {
+                    "name": "syft:metadata:goCompiledVersion",
+                    "value": "go1.22.2"
+                },
+                {
+                    "name": "syft:metadata:h1Digest",
+                    "value": "h1:TjuY4OBNbxmHWSwO3tosgqs5I3biyY8sQPny/eCMTYw="
+                },
+                {
+                    "name": "syft:metadata:mainModule",
+                    "value": "github.com/bomctl/bomctl"
+                }
+            ]
+        },
+        {
+            "bom-ref": "pkg:golang/github.com/cloudflare/circl@v1.3.7?package-id=0316148712e43103",
+            "type": "library",
+            "name": "github.com/cloudflare/circl",
+            "version": "v1.3.7",
+            "cpe": "cpe:2.3:a:cloudflare:circl:v1.3.7:*:*:*:*:*:*:*",
+            "purl": "pkg:golang/github.com/cloudflare/circl@v1.3.7",
+            "properties": [
+                {
+                    "name": "syft:package:foundBy",
+                    "value": "go-module-binary-cataloger"
+                },
+                {
+                    "name": "syft:package:language",
+                    "value": "go"
+                },
+                {
+                    "name": "syft:package:type",
+                    "value": "go-module"
+                },
+                {
+                    "name": "syft:package:metadataType",
+                    "value": "go-module-buildinfo-entry"
+                },
+                {
+                    "name": "syft:location:0:path",
+                    "value": "bomctl"
+                },
+                {
+                    "name": "syft:metadata:architecture",
+                    "value": "amd64"
+                },
+                {
+                    "name": "syft:metadata:goCompiledVersion",
+                    "value": "go1.22.2"
+                },
+                {
+                    "name": "syft:metadata:h1Digest",
+                    "value": "h1:qlCDlTPz2n9fu58M0Nh1J/JzcFpfgkFHHX3O35r5vcU="
+                },
+                {
+                    "name": "syft:metadata:mainModule",
+                    "value": "github.com/bomctl/bomctl"
+                }
+            ]
+        },
+        {
+            "bom-ref": "pkg:golang/github.com/cyphar/filepath-securejoin@v0.2.4?package-id=6f87262783c3a899",
+            "type": "library",
+            "name": "github.com/cyphar/filepath-securejoin",
+            "version": "v0.2.4",
+            "cpe": "cpe:2.3:a:cyphar:filepath-securejoin:v0.2.4:*:*:*:*:*:*:*",
+            "purl": "pkg:golang/github.com/cyphar/filepath-securejoin@v0.2.4",
+            "properties": [
+                {
+                    "name": "syft:package:foundBy",
+                    "value": "go-module-binary-cataloger"
+                },
+                {
+                    "name": "syft:package:language",
+                    "value": "go"
+                },
+                {
+                    "name": "syft:package:type",
+                    "value": "go-module"
+                },
+                {
+                    "name": "syft:package:metadataType",
+                    "value": "go-module-buildinfo-entry"
+                },
+                {
+                    "name": "syft:cpe23",
+                    "value": "cpe:2.3:a:cyphar:filepath_securejoin:v0.2.4:*:*:*:*:*:*:*"
+                },
+                {
+                    "name": "syft:location:0:path",
+                    "value": "bomctl"
+                },
+                {
+                    "name": "syft:metadata:architecture",
+                    "value": "amd64"
+                },
+                {
+                    "name": "syft:metadata:goCompiledVersion",
+                    "value": "go1.22.2"
+                },
+                {
+                    "name": "syft:metadata:h1Digest",
+                    "value": "h1:Ugdm7cg7i6ZK6x3xDF1oEu1nfkyfH53EtKeQYTC3kyg="
+                },
+                {
+                    "name": "syft:metadata:mainModule",
+                    "value": "github.com/bomctl/bomctl"
+                }
+            ]
+        },
+        {
+            "bom-ref": "pkg:golang/github.com/dustin/go-humanize@v1.0.1?package-id=30a4e991f784f426",
+            "type": "library",
+            "name": "github.com/dustin/go-humanize",
+            "version": "v1.0.1",
+            "cpe": "cpe:2.3:a:dustin:go-humanize:v1.0.1:*:*:*:*:*:*:*",
+            "purl": "pkg:golang/github.com/dustin/go-humanize@v1.0.1",
+            "properties": [
+                {
+                    "name": "syft:package:foundBy",
+                    "value": "go-module-binary-cataloger"
+                },
+                {
+                    "name": "syft:package:language",
+                    "value": "go"
+                },
+                {
+                    "name": "syft:package:type",
+                    "value": "go-module"
+                },
+                {
+                    "name": "syft:package:metadataType",
+                    "value": "go-module-buildinfo-entry"
+                },
+                {
+                    "name": "syft:cpe23",
+                    "value": "cpe:2.3:a:dustin:go_humanize:v1.0.1:*:*:*:*:*:*:*"
+                },
+                {
+                    "name": "syft:location:0:path",
+                    "value": "bomctl"
+                },
+                {
+                    "name": "syft:metadata:architecture",
+                    "value": "amd64"
+                },
+                {
+                    "name": "syft:metadata:goCompiledVersion",
+                    "value": "go1.22.2"
+                },
+                {
+                    "name": "syft:metadata:h1Digest",
+                    "value": "h1:GzkhY7T5VNhEkwH0PVJgjz+fX1rhBrR7pRT3mDkpeCY="
+                },
+                {
+                    "name": "syft:metadata:mainModule",
+                    "value": "github.com/bomctl/bomctl"
+                }
+            ]
+        },
+        {
+            "bom-ref": "pkg:golang/github.com/emirpasic/gods@v1.18.1?package-id=603d42c7992383a0",
+            "type": "library",
+            "name": "github.com/emirpasic/gods",
+            "version": "v1.18.1",
+            "cpe": "cpe:2.3:a:emirpasic:gods:v1.18.1:*:*:*:*:*:*:*",
+            "purl": "pkg:golang/github.com/emirpasic/gods@v1.18.1",
+            "properties": [
+                {
+                    "name": "syft:package:foundBy",
+                    "value": "go-module-binary-cataloger"
+                },
+                {
+                    "name": "syft:package:language",
+                    "value": "go"
+                },
+                {
+                    "name": "syft:package:type",
+                    "value": "go-module"
+                },
+                {
+                    "name": "syft:package:metadataType",
+                    "value": "go-module-buildinfo-entry"
+                },
+                {
+                    "name": "syft:location:0:path",
+                    "value": "bomctl"
+                },
+                {
+                    "name": "syft:metadata:architecture",
+                    "value": "amd64"
+                },
+                {
+                    "name": "syft:metadata:goCompiledVersion",
+                    "value": "go1.22.2"
+                },
+                {
+                    "name": "syft:metadata:h1Digest",
+                    "value": "h1:FXtiHYKDGKCW2KzwZKx0iC0PQmdlorYgdFG9jPXJ1Bc="
+                },
+                {
+                    "name": "syft:metadata:mainModule",
+                    "value": "github.com/bomctl/bomctl"
+                }
+            ]
+        },
+        {
+            "bom-ref": "pkg:golang/github.com/fsnotify/fsnotify@v1.6.0?package-id=e67f5f42a874107a",
+            "type": "library",
+            "name": "github.com/fsnotify/fsnotify",
+            "version": "v1.6.0",
+            "cpe": "cpe:2.3:a:fsnotify:fsnotify:v1.6.0:*:*:*:*:*:*:*",
+            "purl": "pkg:golang/github.com/fsnotify/fsnotify@v1.6.0",
+            "properties": [
+                {
+                    "name": "syft:package:foundBy",
+                    "value": "go-module-binary-cataloger"
+                },
+                {
+                    "name": "syft:package:language",
+                    "value": "go"
+                },
+                {
+                    "name": "syft:package:type",
+                    "value": "go-module"
+                },
+                {
+                    "name": "syft:package:metadataType",
+                    "value": "go-module-buildinfo-entry"
+                },
+                {
+                    "name": "syft:location:0:path",
+                    "value": "bomctl"
+                },
+                {
+                    "name": "syft:metadata:architecture",
+                    "value": "amd64"
+                },
+                {
+                    "name": "syft:metadata:goCompiledVersion",
+                    "value": "go1.22.2"
+                },
+                {
+                    "name": "syft:metadata:h1Digest",
+                    "value": "h1:n+5WquG0fcWoWp6xPWfHdbskMCQaFnG6PfBrh1Ky4HY="
+                },
+                {
+                    "name": "syft:metadata:mainModule",
+                    "value": "github.com/bomctl/bomctl"
+                }
+            ]
+        },
+        {
+            "bom-ref": "pkg:golang/github.com/glebarez/go-sqlite@v1.22.0?package-id=4c961a9843695aa6",
+            "type": "library",
+            "name": "github.com/glebarez/go-sqlite",
+            "version": "v1.22.0",
+            "cpe": "cpe:2.3:a:glebarez:go-sqlite:v1.22.0:*:*:*:*:*:*:*",
+            "purl": "pkg:golang/github.com/glebarez/go-sqlite@v1.22.0",
+            "properties": [
+                {
+                    "name": "syft:package:foundBy",
+                    "value": "go-module-binary-cataloger"
+                },
+                {
+                    "name": "syft:package:language",
+                    "value": "go"
+                },
+                {
+                    "name": "syft:package:type",
+                    "value": "go-module"
+                },
+                {
+                    "name": "syft:package:metadataType",
+                    "value": "go-module-buildinfo-entry"
+                },
+                {
+                    "name": "syft:cpe23",
+                    "value": "cpe:2.3:a:glebarez:go_sqlite:v1.22.0:*:*:*:*:*:*:*"
+                },
+                {
+                    "name": "syft:location:0:path",
+                    "value": "bomctl"
+                },
+                {
+                    "name": "syft:metadata:architecture",
+                    "value": "amd64"
+                },
+                {
+                    "name": "syft:metadata:goCompiledVersion",
+                    "value": "go1.22.2"
+                },
+                {
+                    "name": "syft:metadata:h1Digest",
+                    "value": "h1:uAcMJhaA6r3LHMTFgP0SifzgXg46yJkgxqyuyec+ruQ="
+                },
+                {
+                    "name": "syft:metadata:mainModule",
+                    "value": "github.com/bomctl/bomctl"
+                }
+            ]
+        },
+        {
+            "bom-ref": "pkg:golang/github.com/glebarez/sqlite@v1.10.0?package-id=46019d4c06cb610e",
+            "type": "library",
+            "name": "github.com/glebarez/sqlite",
+            "version": "v1.10.0",
+            "cpe": "cpe:2.3:a:glebarez:sqlite:v1.10.0:*:*:*:*:*:*:*",
+            "purl": "pkg:golang/github.com/glebarez/sqlite@v1.10.0",
+            "properties": [
+                {
+                    "name": "syft:package:foundBy",
+                    "value": "go-module-binary-cataloger"
+                },
+                {
+                    "name": "syft:package:language",
+                    "value": "go"
+                },
+                {
+                    "name": "syft:package:type",
+                    "value": "go-module"
+                },
+                {
+                    "name": "syft:package:metadataType",
+                    "value": "go-module-buildinfo-entry"
+                },
+                {
+                    "name": "syft:location:0:path",
+                    "value": "bomctl"
+                },
+                {
+                    "name": "syft:metadata:architecture",
+                    "value": "amd64"
+                },
+                {
+                    "name": "syft:metadata:goCompiledVersion",
+                    "value": "go1.22.2"
+                },
+                {
+                    "name": "syft:metadata:h1Digest",
+                    "value": "h1:u4gt8y7OND/cCei/NMHmfbLxF6xP2wgKcT/BJf2pYkc="
+                },
+                {
+                    "name": "syft:metadata:mainModule",
+                    "value": "github.com/bomctl/bomctl"
+                }
+            ]
+        },
+        {
+            "bom-ref": "pkg:golang/github.com/go-git/gcfg@v1.5.1-0.20230307220236-3a3c6141e376?package-id=01ab9f902ede1e82",
+            "type": "library",
+            "name": "github.com/go-git/gcfg",
+            "version": "v1.5.1-0.20230307220236-3a3c6141e376",
+            "cpe": "cpe:2.3:a:go-git:gcfg:v1.5.1-0.20230307220236-3a3c6141e376:*:*:*:*:*:*:*",
+            "purl": "pkg:golang/github.com/go-git/gcfg@v1.5.1-0.20230307220236-3a3c6141e376",
+            "properties": [
+                {
+                    "name": "syft:package:foundBy",
+                    "value": "go-module-binary-cataloger"
+                },
+                {
+                    "name": "syft:package:language",
+                    "value": "go"
+                },
+                {
+                    "name": "syft:package:type",
+                    "value": "go-module"
+                },
+                {
+                    "name": "syft:package:metadataType",
+                    "value": "go-module-buildinfo-entry"
+                },
+                {
+                    "name": "syft:cpe23",
+                    "value": "cpe:2.3:a:go_git:gcfg:v1.5.1-0.20230307220236-3a3c6141e376:*:*:*:*:*:*:*"
+                },
+                {
+                    "name": "syft:cpe23",
+                    "value": "cpe:2.3:a:go:gcfg:v1.5.1-0.20230307220236-3a3c6141e376:*:*:*:*:*:*:*"
+                },
+                {
+                    "name": "syft:location:0:path",
+                    "value": "bomctl"
+                },
+                {
+                    "name": "syft:metadata:architecture",
+                    "value": "amd64"
+                },
+                {
+                    "name": "syft:metadata:goCompiledVersion",
+                    "value": "go1.22.2"
+                },
+                {
+                    "name": "syft:metadata:h1Digest",
+                    "value": "h1:+zs/tPmkDkHx3U66DAb0lQFJrpS6731Oaa12ikc+DiI="
+                },
+                {
+                    "name": "syft:metadata:mainModule",
+                    "value": "github.com/bomctl/bomctl"
+                }
+            ]
+        },
+        {
+            "bom-ref": "pkg:golang/github.com/go-git/go-billy@v5.5.0?package-id=b13eebcf55ab5c39#v5",
+            "type": "library",
+            "name": "github.com/go-git/go-billy/v5",
+            "version": "v5.5.0",
+            "cpe": "cpe:2.3:a:go-git:go-billy\\/v5:v5.5.0:*:*:*:*:*:*:*",
+            "purl": "pkg:golang/github.com/go-git/go-billy@v5.5.0#v5",
+            "properties": [
+                {
+                    "name": "syft:package:foundBy",
+                    "value": "go-module-binary-cataloger"
+                },
+                {
+                    "name": "syft:package:language",
+                    "value": "go"
+                },
+                {
+                    "name": "syft:package:type",
+                    "value": "go-module"
+                },
+                {
+                    "name": "syft:package:metadataType",
+                    "value": "go-module-buildinfo-entry"
+                },
+                {
+                    "name": "syft:cpe23",
+                    "value": "cpe:2.3:a:go-git:go_billy\\/v5:v5.5.0:*:*:*:*:*:*:*"
+                },
+                {
+                    "name": "syft:cpe23",
+                    "value": "cpe:2.3:a:go_git:go-billy\\/v5:v5.5.0:*:*:*:*:*:*:*"
+                },
+                {
+                    "name": "syft:cpe23",
+                    "value": "cpe:2.3:a:go_git:go_billy\\/v5:v5.5.0:*:*:*:*:*:*:*"
+                },
+                {
+                    "name": "syft:cpe23",
+                    "value": "cpe:2.3:a:go:go-billy\\/v5:v5.5.0:*:*:*:*:*:*:*"
+                },
+                {
+                    "name": "syft:cpe23",
+                    "value": "cpe:2.3:a:go:go_billy\\/v5:v5.5.0:*:*:*:*:*:*:*"
+                },
+                {
+                    "name": "syft:location:0:path",
+                    "value": "bomctl"
+                },
+                {
+                    "name": "syft:metadata:architecture",
+                    "value": "amd64"
+                },
+                {
+                    "name": "syft:metadata:goCompiledVersion",
+                    "value": "go1.22.2"
+                },
+                {
+                    "name": "syft:metadata:h1Digest",
+                    "value": "h1:yEY4yhzCDuMGSv83oGxiBotRzhwhNr8VZyphhiu+mTU="
+                },
+                {
+                    "name": "syft:metadata:mainModule",
+                    "value": "github.com/bomctl/bomctl"
+                }
+            ]
+        },
+        {
+            "bom-ref": "pkg:golang/github.com/go-git/go-git@v5.11.0?package-id=7f9552f8ad5636a7#v5",
+            "type": "library",
+            "name": "github.com/go-git/go-git/v5",
+            "version": "v5.11.0",
+            "cpe": "cpe:2.3:a:go-git:go-git\\/v5:v5.11.0:*:*:*:*:*:*:*",
+            "purl": "pkg:golang/github.com/go-git/go-git@v5.11.0#v5",
+            "properties": [
+                {
+                    "name": "syft:package:foundBy",
+                    "value": "go-module-binary-cataloger"
+                },
+                {
+                    "name": "syft:package:language",
+                    "value": "go"
+                },
+                {
+                    "name": "syft:package:type",
+                    "value": "go-module"
+                },
+                {
+                    "name": "syft:package:metadataType",
+                    "value": "go-module-buildinfo-entry"
+                },
+                {
+                    "name": "syft:cpe23",
+                    "value": "cpe:2.3:a:go-git:go_git\\/v5:v5.11.0:*:*:*:*:*:*:*"
+                },
+                {
+                    "name": "syft:cpe23",
+                    "value": "cpe:2.3:a:go_git:go-git\\/v5:v5.11.0:*:*:*:*:*:*:*"
+                },
+                {
+                    "name": "syft:cpe23",
+                    "value": "cpe:2.3:a:go_git:go_git\\/v5:v5.11.0:*:*:*:*:*:*:*"
+                },
+                {
+                    "name": "syft:cpe23",
+                    "value": "cpe:2.3:a:go:go-git\\/v5:v5.11.0:*:*:*:*:*:*:*"
+                },
+                {
+                    "name": "syft:cpe23",
+                    "value": "cpe:2.3:a:go:go_git\\/v5:v5.11.0:*:*:*:*:*:*:*"
+                },
+                {
+                    "name": "syft:location:0:path",
+                    "value": "bomctl"
+                },
+                {
+                    "name": "syft:metadata:architecture",
+                    "value": "amd64"
+                },
+                {
+                    "name": "syft:metadata:goCompiledVersion",
+                    "value": "go1.22.2"
+                },
+                {
+                    "name": "syft:metadata:h1Digest",
+                    "value": "h1:XIZc1p+8YzypNr34itUfSvYJcv+eYdTnTvOZ2vD3cA4="
+                },
+                {
+                    "name": "syft:metadata:mainModule",
+                    "value": "github.com/bomctl/bomctl"
+                }
+            ]
+        },
+        {
+            "bom-ref": "pkg:golang/github.com/go-logfmt/logfmt@v0.6.0?package-id=ee72a30da1b1b103",
+            "type": "library",
+            "name": "github.com/go-logfmt/logfmt",
+            "version": "v0.6.0",
+            "cpe": "cpe:2.3:a:go-logfmt:logfmt:v0.6.0:*:*:*:*:*:*:*",
+            "purl": "pkg:golang/github.com/go-logfmt/logfmt@v0.6.0",
+            "properties": [
+                {
+                    "name": "syft:package:foundBy",
+                    "value": "go-module-binary-cataloger"
+                },
+                {
+                    "name": "syft:package:language",
+                    "value": "go"
+                },
+                {
+                    "name": "syft:package:type",
+                    "value": "go-module"
+                },
+                {
+                    "name": "syft:package:metadataType",
+                    "value": "go-module-buildinfo-entry"
+                },
+                {
+                    "name": "syft:cpe23",
+                    "value": "cpe:2.3:a:go_logfmt:logfmt:v0.6.0:*:*:*:*:*:*:*"
+                },
+                {
+                    "name": "syft:cpe23",
+                    "value": "cpe:2.3:a:go:logfmt:v0.6.0:*:*:*:*:*:*:*"
+                },
+                {
+                    "name": "syft:location:0:path",
+                    "value": "bomctl"
+                },
+                {
+                    "name": "syft:metadata:architecture",
+                    "value": "amd64"
+                },
+                {
+                    "name": "syft:metadata:goCompiledVersion",
+                    "value": "go1.22.2"
+                },
+                {
+                    "name": "syft:metadata:h1Digest",
+                    "value": "h1:wGYYu3uicYdqXVgoYbvnkrPVXkuLM1p1ifugDMEdRi4="
+                },
+                {
+                    "name": "syft:metadata:mainModule",
+                    "value": "github.com/bomctl/bomctl"
+                }
+            ]
+        },
+        {
+            "bom-ref": "pkg:golang/github.com/golang/groupcache@v0.0.0-20210331224755-41bb18bfe9da?package-id=acfc5ab3cd06c636",
+            "type": "library",
+            "name": "github.com/golang/groupcache",
+            "version": "v0.0.0-20210331224755-41bb18bfe9da",
+            "cpe": "cpe:2.3:a:golang:groupcache:v0.0.0-20210331224755-41bb18bfe9da:*:*:*:*:*:*:*",
+            "purl": "pkg:golang/github.com/golang/groupcache@v0.0.0-20210331224755-41bb18bfe9da",
+            "properties": [
+                {
+                    "name": "syft:package:foundBy",
+                    "value": "go-module-binary-cataloger"
+                },
+                {
+                    "name": "syft:package:language",
+                    "value": "go"
+                },
+                {
+                    "name": "syft:package:type",
+                    "value": "go-module"
+                },
+                {
+                    "name": "syft:package:metadataType",
+                    "value": "go-module-buildinfo-entry"
+                },
+                {
+                    "name": "syft:location:0:path",
+                    "value": "bomctl"
+                },
+                {
+                    "name": "syft:metadata:architecture",
+                    "value": "amd64"
+                },
+                {
+                    "name": "syft:metadata:goCompiledVersion",
+                    "value": "go1.22.2"
+                },
+                {
+                    "name": "syft:metadata:h1Digest",
+                    "value": "h1:oI5xCqsCo564l8iNU+DwB5epxmsaqB+rhGL0m5jtYqE="
+                },
+                {
+                    "name": "syft:metadata:mainModule",
+                    "value": "github.com/bomctl/bomctl"
+                }
+            ]
+        },
+        {
+            "bom-ref": "pkg:golang/github.com/golang/protobuf@v1.5.3?package-id=a10f1e67815277eb",
+            "type": "library",
+            "name": "github.com/golang/protobuf",
+            "version": "v1.5.3",
+            "cpe": "cpe:2.3:a:golang:protobuf:v1.5.3:*:*:*:*:*:*:*",
+            "purl": "pkg:golang/github.com/golang/protobuf@v1.5.3",
+            "properties": [
+                {
+                    "name": "syft:package:foundBy",
+                    "value": "go-module-binary-cataloger"
+                },
+                {
+                    "name": "syft:package:language",
+                    "value": "go"
+                },
+                {
+                    "name": "syft:package:type",
+                    "value": "go-module"
+                },
+                {
+                    "name": "syft:package:metadataType",
+                    "value": "go-module-buildinfo-entry"
+                },
+                {
+                    "name": "syft:location:0:path",
+                    "value": "bomctl"
+                },
+                {
+                    "name": "syft:metadata:architecture",
+                    "value": "amd64"
+                },
+                {
+                    "name": "syft:metadata:goCompiledVersion",
+                    "value": "go1.22.2"
+                },
+                {
+                    "name": "syft:metadata:h1Digest",
+                    "value": "h1:KhyjKVUg7Usr/dYsdSqoFveMYd5ko72D+zANwlG1mmg="
+                },
+                {
+                    "name": "syft:metadata:mainModule",
+                    "value": "github.com/bomctl/bomctl"
+                }
+            ]
+        },
+        {
+            "bom-ref": "pkg:golang/github.com/google/go-cmp@v0.6.0?package-id=02581c34665b33a4",
+            "type": "library",
+            "name": "github.com/google/go-cmp",
+            "version": "v0.6.0",
+            "cpe": "cpe:2.3:a:google:go-cmp:v0.6.0:*:*:*:*:*:*:*",
+            "purl": "pkg:golang/github.com/google/go-cmp@v0.6.0",
+            "properties": [
+                {
+                    "name": "syft:package:foundBy",
+                    "value": "go-module-binary-cataloger"
+                },
+                {
+                    "name": "syft:package:language",
+                    "value": "go"
+                },
+                {
+                    "name": "syft:package:type",
+                    "value": "go-module"
+                },
+                {
+                    "name": "syft:package:metadataType",
+                    "value": "go-module-buildinfo-entry"
+                },
+                {
+                    "name": "syft:cpe23",
+                    "value": "cpe:2.3:a:google:go_cmp:v0.6.0:*:*:*:*:*:*:*"
+                },
+                {
+                    "name": "syft:location:0:path",
+                    "value": "bomctl"
+                },
+                {
+                    "name": "syft:metadata:architecture",
+                    "value": "amd64"
+                },
+                {
+                    "name": "syft:metadata:goCompiledVersion",
+                    "value": "go1.22.2"
+                },
+                {
+                    "name": "syft:metadata:h1Digest",
+                    "value": "h1:ofyhxvXcZhMsU5ulbFiLKl/XBFqE1GSq7atu8tAmTRI="
+                },
+                {
+                    "name": "syft:metadata:mainModule",
+                    "value": "github.com/bomctl/bomctl"
+                }
+            ]
+        },
+        {
+            "bom-ref": "pkg:golang/github.com/google/uuid@v1.6.0?package-id=32d95a99eef6571e",
+            "type": "library",
+            "name": "github.com/google/uuid",
+            "version": "v1.6.0",
+            "cpe": "cpe:2.3:a:google:uuid:v1.6.0:*:*:*:*:*:*:*",
+            "purl": "pkg:golang/github.com/google/uuid@v1.6.0",
+            "properties": [
+                {
+                    "name": "syft:package:foundBy",
+                    "value": "go-module-binary-cataloger"
+                },
+                {
+                    "name": "syft:package:language",
+                    "value": "go"
+                },
+                {
+                    "name": "syft:package:type",
+                    "value": "go-module"
+                },
+                {
+                    "name": "syft:package:metadataType",
+                    "value": "go-module-buildinfo-entry"
+                },
+                {
+                    "name": "syft:location:0:path",
+                    "value": "bomctl"
+                },
+                {
+                    "name": "syft:metadata:architecture",
+                    "value": "amd64"
+                },
+                {
+                    "name": "syft:metadata:goCompiledVersion",
+                    "value": "go1.22.2"
+                },
+                {
+                    "name": "syft:metadata:h1Digest",
+                    "value": "h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0="
+                },
+                {
+                    "name": "syft:metadata:mainModule",
+                    "value": "github.com/bomctl/bomctl"
+                }
+            ]
+        },
+        {
+            "bom-ref": "pkg:golang/github.com/grpc-ecosystem/go-grpc-middleware@v1.4.0?package-id=01867f7fe3cc9f73",
+            "type": "library",
+            "name": "github.com/grpc-ecosystem/go-grpc-middleware",
+            "version": "v1.4.0",
+            "cpe": "cpe:2.3:a:grpc-ecosystem:go-grpc-middleware:v1.4.0:*:*:*:*:*:*:*",
+            "purl": "pkg:golang/github.com/grpc-ecosystem/go-grpc-middleware@v1.4.0",
+            "properties": [
+                {
+                    "name": "syft:package:foundBy",
+                    "value": "go-module-binary-cataloger"
+                },
+                {
+                    "name": "syft:package:language",
+                    "value": "go"
+                },
+                {
+                    "name": "syft:package:type",
+                    "value": "go-module"
+                },
+                {
+                    "name": "syft:package:metadataType",
+                    "value": "go-module-buildinfo-entry"
+                },
+                {
+                    "name": "syft:cpe23",
+                    "value": "cpe:2.3:a:grpc-ecosystem:go_grpc_middleware:v1.4.0:*:*:*:*:*:*:*"
+                },
+                {
+                    "name": "syft:cpe23",
+                    "value": "cpe:2.3:a:grpc_ecosystem:go-grpc-middleware:v1.4.0:*:*:*:*:*:*:*"
+                },
+                {
+                    "name": "syft:cpe23",
+                    "value": "cpe:2.3:a:grpc_ecosystem:go_grpc_middleware:v1.4.0:*:*:*:*:*:*:*"
+                },
+                {
+                    "name": "syft:cpe23",
+                    "value": "cpe:2.3:a:grpc:go-grpc-middleware:v1.4.0:*:*:*:*:*:*:*"
+                },
+                {
+                    "name": "syft:cpe23",
+                    "value": "cpe:2.3:a:grpc:go_grpc_middleware:v1.4.0:*:*:*:*:*:*:*"
+                },
+                {
+                    "name": "syft:location:0:path",
+                    "value": "bomctl"
+                },
+                {
+                    "name": "syft:metadata:architecture",
+                    "value": "amd64"
+                },
+                {
+                    "name": "syft:metadata:goCompiledVersion",
+                    "value": "go1.22.2"
+                },
+                {
+                    "name": "syft:metadata:h1Digest",
+                    "value": "h1:UH//fgunKIs4JdUbpDl1VZCDaL56wXCB/5+wF6uHfaI="
+                },
+                {
+                    "name": "syft:metadata:mainModule",
+                    "value": "github.com/bomctl/bomctl"
+                }
+            ]
+        },
+        {
+            "bom-ref": "pkg:golang/github.com/grpc-ecosystem/grpc-gateway@v2.19.0?package-id=2525cb49ed73fed0#v2",
+            "type": "library",
+            "name": "github.com/grpc-ecosystem/grpc-gateway/v2",
+            "version": "v2.19.0",
+            "cpe": "cpe:2.3:a:grpc-ecosystem:grpc-gateway\\/v2:v2.19.0:*:*:*:*:*:*:*",
+            "purl": "pkg:golang/github.com/grpc-ecosystem/grpc-gateway@v2.19.0#v2",
+            "properties": [
+                {
+                    "name": "syft:package:foundBy",
+                    "value": "go-module-binary-cataloger"
+                },
+                {
+                    "name": "syft:package:language",
+                    "value": "go"
+                },
+                {
+                    "name": "syft:package:type",
+                    "value": "go-module"
+                },
+                {
+                    "name": "syft:package:metadataType",
+                    "value": "go-module-buildinfo-entry"
+                },
+                {
+                    "name": "syft:cpe23",
+                    "value": "cpe:2.3:a:grpc-ecosystem:grpc_gateway\\/v2:v2.19.0:*:*:*:*:*:*:*"
+                },
+                {
+                    "name": "syft:cpe23",
+                    "value": "cpe:2.3:a:grpc_ecosystem:grpc-gateway\\/v2:v2.19.0:*:*:*:*:*:*:*"
+                },
+                {
+                    "name": "syft:cpe23",
+                    "value": "cpe:2.3:a:grpc_ecosystem:grpc_gateway\\/v2:v2.19.0:*:*:*:*:*:*:*"
+                },
+                {
+                    "name": "syft:cpe23",
+                    "value": "cpe:2.3:a:grpc:grpc-gateway\\/v2:v2.19.0:*:*:*:*:*:*:*"
+                },
+                {
+                    "name": "syft:cpe23",
+                    "value": "cpe:2.3:a:grpc:grpc_gateway\\/v2:v2.19.0:*:*:*:*:*:*:*"
+                },
+                {
+                    "name": "syft:location:0:path",
+                    "value": "bomctl"
+                },
+                {
+                    "name": "syft:metadata:architecture",
+                    "value": "amd64"
+                },
+                {
+                    "name": "syft:metadata:goCompiledVersion",
+                    "value": "go1.22.2"
+                },
+                {
+                    "name": "syft:metadata:h1Digest",
+                    "value": "h1:Wqo399gCIufwto+VfwCSvsnfGpF/w5E9CNxSwbpD6No="
+                },
+                {
+                    "name": "syft:metadata:mainModule",
+                    "value": "github.com/bomctl/bomctl"
+                }
+            ]
+        },
+        {
+            "bom-ref": "pkg:golang/github.com/hashicorp/hcl@v1.0.0?package-id=cbe9a3ba0f5cca98",
+            "type": "library",
+            "name": "github.com/hashicorp/hcl",
+            "version": "v1.0.0",
+            "cpe": "cpe:2.3:a:hashicorp:hcl:v1.0.0:*:*:*:*:*:*:*",
+            "purl": "pkg:golang/github.com/hashicorp/hcl@v1.0.0",
+            "properties": [
+                {
+                    "name": "syft:package:foundBy",
+                    "value": "go-module-binary-cataloger"
+                },
+                {
+                    "name": "syft:package:language",
+                    "value": "go"
+                },
+                {
+                    "name": "syft:package:type",
+                    "value": "go-module"
+                },
+                {
+                    "name": "syft:package:metadataType",
+                    "value": "go-module-buildinfo-entry"
+                },
+                {
+                    "name": "syft:location:0:path",
+                    "value": "bomctl"
+                },
+                {
+                    "name": "syft:metadata:architecture",
+                    "value": "amd64"
+                },
+                {
+                    "name": "syft:metadata:goCompiledVersion",
+                    "value": "go1.22.2"
+                },
+                {
+                    "name": "syft:metadata:h1Digest",
+                    "value": "h1:0Anlzjpi4vEasTeNFn2mLJgTSwt0+6sfsiTG8qcWGx4="
+                },
+                {
+                    "name": "syft:metadata:mainModule",
+                    "value": "github.com/bomctl/bomctl"
+                }
+            ]
+        },
+        {
+            "bom-ref": "pkg:golang/github.com/infobloxopen/atlas-app-toolkit@v1.4.0?package-id=f59850594d789961",
+            "type": "library",
+            "name": "github.com/infobloxopen/atlas-app-toolkit",
+            "version": "v1.4.0",
+            "cpe": "cpe:2.3:a:infobloxopen:atlas-app-toolkit:v1.4.0:*:*:*:*:*:*:*",
+            "purl": "pkg:golang/github.com/infobloxopen/atlas-app-toolkit@v1.4.0",
+            "properties": [
+                {
+                    "name": "syft:package:foundBy",
+                    "value": "go-module-binary-cataloger"
+                },
+                {
+                    "name": "syft:package:language",
+                    "value": "go"
+                },
+                {
+                    "name": "syft:package:type",
+                    "value": "go-module"
+                },
+                {
+                    "name": "syft:package:metadataType",
+                    "value": "go-module-buildinfo-entry"
+                },
+                {
+                    "name": "syft:cpe23",
+                    "value": "cpe:2.3:a:infobloxopen:atlas_app_toolkit:v1.4.0:*:*:*:*:*:*:*"
+                },
+                {
+                    "name": "syft:location:0:path",
+                    "value": "bomctl"
+                },
+                {
+                    "name": "syft:metadata:architecture",
+                    "value": "amd64"
+                },
+                {
+                    "name": "syft:metadata:goCompiledVersion",
+                    "value": "go1.22.2"
+                },
+                {
+                    "name": "syft:metadata:h1Digest",
+                    "value": "h1:cAaSeFd94/LonbiukVipbnKGmQehlJ2JbScBf1ZR87k="
+                },
+                {
+                    "name": "syft:metadata:mainModule",
+                    "value": "github.com/bomctl/bomctl"
+                }
+            ]
+        },
+        {
+            "bom-ref": "pkg:golang/github.com/infobloxopen/protoc-gen-gorm@v1.1.3-0.20231122062459-d3024d4fa7c9?package-id=448461908dd9bc4e",
+            "type": "library",
+            "name": "github.com/infobloxopen/protoc-gen-gorm",
+            "version": "v1.1.3-0.20231122062459-d3024d4fa7c9",
+            "cpe": "cpe:2.3:a:infobloxopen:protoc-gen-gorm:v1.1.3-0.20231122062459-d3024d4fa7c9:*:*:*:*:*:*:*",
+            "purl": "pkg:golang/github.com/infobloxopen/protoc-gen-gorm@v1.1.3-0.20231122062459-d3024d4fa7c9",
+            "properties": [
+                {
+                    "name": "syft:package:foundBy",
+                    "value": "go-module-binary-cataloger"
+                },
+                {
+                    "name": "syft:package:language",
+                    "value": "go"
+                },
+                {
+                    "name": "syft:package:type",
+                    "value": "go-module"
+                },
+                {
+                    "name": "syft:package:metadataType",
+                    "value": "go-module-buildinfo-entry"
+                },
+                {
+                    "name": "syft:cpe23",
+                    "value": "cpe:2.3:a:infobloxopen:protoc_gen_gorm:v1.1.3-0.20231122062459-d3024d4fa7c9:*:*:*:*:*:*:*"
+                },
+                {
+                    "name": "syft:location:0:path",
+                    "value": "bomctl"
+                },
+                {
+                    "name": "syft:metadata:architecture",
+                    "value": "amd64"
+                },
+                {
+                    "name": "syft:metadata:goCompiledVersion",
+                    "value": "go1.22.2"
+                },
+                {
+                    "name": "syft:metadata:h1Digest",
+                    "value": "h1:CAt9vbIHhNhmMulPSJzVEEra9hz0N0mUKBqG9dvUMGk="
+                },
+                {
+                    "name": "syft:metadata:mainModule",
+                    "value": "github.com/bomctl/bomctl"
+                }
+            ]
+        },
+        {
+            "bom-ref": "pkg:golang/github.com/jbenet/go-context@v0.0.0-20150711004518-d14ea06fba99?package-id=ee4d5aca21e42f11",
+            "type": "library",
+            "name": "github.com/jbenet/go-context",
+            "version": "v0.0.0-20150711004518-d14ea06fba99",
+            "cpe": "cpe:2.3:a:jbenet:go-context:v0.0.0-20150711004518-d14ea06fba99:*:*:*:*:*:*:*",
+            "purl": "pkg:golang/github.com/jbenet/go-context@v0.0.0-20150711004518-d14ea06fba99",
+            "properties": [
+                {
+                    "name": "syft:package:foundBy",
+                    "value": "go-module-binary-cataloger"
+                },
+                {
+                    "name": "syft:package:language",
+                    "value": "go"
+                },
+                {
+                    "name": "syft:package:type",
+                    "value": "go-module"
+                },
+                {
+                    "name": "syft:package:metadataType",
+                    "value": "go-module-buildinfo-entry"
+                },
+                {
+                    "name": "syft:cpe23",
+                    "value": "cpe:2.3:a:jbenet:go_context:v0.0.0-20150711004518-d14ea06fba99:*:*:*:*:*:*:*"
+                },
+                {
+                    "name": "syft:location:0:path",
+                    "value": "bomctl"
+                },
+                {
+                    "name": "syft:metadata:architecture",
+                    "value": "amd64"
+                },
+                {
+                    "name": "syft:metadata:goCompiledVersion",
+                    "value": "go1.22.2"
+                },
+                {
+                    "name": "syft:metadata:h1Digest",
+                    "value": "h1:BQSFePA1RWJOlocH6Fxy8MmwDt+yVQYULKfN0RoTN8A="
+                },
+                {
+                    "name": "syft:metadata:mainModule",
+                    "value": "github.com/bomctl/bomctl"
+                }
+            ]
+        },
+        {
+            "bom-ref": "pkg:golang/github.com/jdx/go-netrc@v1.0.0?package-id=86abea4558accc80",
+            "type": "library",
+            "name": "github.com/jdx/go-netrc",
+            "version": "v1.0.0",
+            "cpe": "cpe:2.3:a:jdx:go-netrc:v1.0.0:*:*:*:*:*:*:*",
+            "purl": "pkg:golang/github.com/jdx/go-netrc@v1.0.0",
+            "properties": [
+                {
+                    "name": "syft:package:foundBy",
+                    "value": "go-module-binary-cataloger"
+                },
+                {
+                    "name": "syft:package:language",
+                    "value": "go"
+                },
+                {
+                    "name": "syft:package:type",
+                    "value": "go-module"
+                },
+                {
+                    "name": "syft:package:metadataType",
+                    "value": "go-module-buildinfo-entry"
+                },
+                {
+                    "name": "syft:cpe23",
+                    "value": "cpe:2.3:a:jdx:go_netrc:v1.0.0:*:*:*:*:*:*:*"
+                },
+                {
+                    "name": "syft:location:0:path",
+                    "value": "bomctl"
+                },
+                {
+                    "name": "syft:metadata:architecture",
+                    "value": "amd64"
+                },
+                {
+                    "name": "syft:metadata:goCompiledVersion",
+                    "value": "go1.22.2"
+                },
+                {
+                    "name": "syft:metadata:h1Digest",
+                    "value": "h1:QbLMLyCZGj0NA8glAhxUpf1zDg6cxnWgMBbjq40W0gQ="
+                },
+                {
+                    "name": "syft:metadata:mainModule",
+                    "value": "github.com/bomctl/bomctl"
+                }
+            ]
+        },
+        {
+            "bom-ref": "pkg:golang/github.com/jinzhu/gorm@v1.9.16?package-id=6a06106defc5ff27",
+            "type": "library",
+            "name": "github.com/jinzhu/gorm",
+            "version": "v1.9.16",
+            "cpe": "cpe:2.3:a:jinzhu:gorm:v1.9.16:*:*:*:*:*:*:*",
+            "purl": "pkg:golang/github.com/jinzhu/gorm@v1.9.16",
+            "properties": [
+                {
+                    "name": "syft:package:foundBy",
+                    "value": "go-module-binary-cataloger"
+                },
+                {
+                    "name": "syft:package:language",
+                    "value": "go"
+                },
+                {
+                    "name": "syft:package:type",
+                    "value": "go-module"
+                },
+                {
+                    "name": "syft:package:metadataType",
+                    "value": "go-module-buildinfo-entry"
+                },
+                {
+                    "name": "syft:location:0:path",
+                    "value": "bomctl"
+                },
+                {
+                    "name": "syft:metadata:architecture",
+                    "value": "amd64"
+                },
+                {
+                    "name": "syft:metadata:goCompiledVersion",
+                    "value": "go1.22.2"
+                },
+                {
+                    "name": "syft:metadata:h1Digest",
+                    "value": "h1:+IyIjPEABKRpsu/F8OvDPy9fyQlgsg2luMV2ZIH5i5o="
+                },
+                {
+                    "name": "syft:metadata:mainModule",
+                    "value": "github.com/bomctl/bomctl"
+                }
+            ]
+        },
+        {
+            "bom-ref": "pkg:golang/github.com/jinzhu/inflection@v1.0.0?package-id=1664dbf0997fec9c",
+            "type": "library",
+            "name": "github.com/jinzhu/inflection",
+            "version": "v1.0.0",
+            "cpe": "cpe:2.3:a:jinzhu:inflection:v1.0.0:*:*:*:*:*:*:*",
+            "purl": "pkg:golang/github.com/jinzhu/inflection@v1.0.0",
+            "properties": [
+                {
+                    "name": "syft:package:foundBy",
+                    "value": "go-module-binary-cataloger"
+                },
+                {
+                    "name": "syft:package:language",
+                    "value": "go"
+                },
+                {
+                    "name": "syft:package:type",
+                    "value": "go-module"
+                },
+                {
+                    "name": "syft:package:metadataType",
+                    "value": "go-module-buildinfo-entry"
+                },
+                {
+                    "name": "syft:location:0:path",
+                    "value": "bomctl"
+                },
+                {
+                    "name": "syft:metadata:architecture",
+                    "value": "amd64"
+                },
+                {
+                    "name": "syft:metadata:goCompiledVersion",
+                    "value": "go1.22.2"
+                },
+                {
+                    "name": "syft:metadata:h1Digest",
+                    "value": "h1:K317FqzuhWc8YvSVlFMCCUb36O/S9MCKRDI7QkRKD/E="
+                },
+                {
+                    "name": "syft:metadata:mainModule",
+                    "value": "github.com/bomctl/bomctl"
+                }
+            ]
+        },
+        {
+            "bom-ref": "pkg:golang/github.com/jinzhu/now@v1.1.5?package-id=ba53a66daa910917",
+            "type": "library",
+            "name": "github.com/jinzhu/now",
+            "version": "v1.1.5",
+            "cpe": "cpe:2.3:a:jinzhu:now:v1.1.5:*:*:*:*:*:*:*",
+            "purl": "pkg:golang/github.com/jinzhu/now@v1.1.5",
+            "properties": [
+                {
+                    "name": "syft:package:foundBy",
+                    "value": "go-module-binary-cataloger"
+                },
+                {
+                    "name": "syft:package:language",
+                    "value": "go"
+                },
+                {
+                    "name": "syft:package:type",
+                    "value": "go-module"
+                },
+                {
+                    "name": "syft:package:metadataType",
+                    "value": "go-module-buildinfo-entry"
+                },
+                {
+                    "name": "syft:location:0:path",
+                    "value": "bomctl"
+                },
+                {
+                    "name": "syft:metadata:architecture",
+                    "value": "amd64"
+                },
+                {
+                    "name": "syft:metadata:goCompiledVersion",
+                    "value": "go1.22.2"
+                },
+                {
+                    "name": "syft:metadata:h1Digest",
+                    "value": "h1:/o9tlHleP7gOFmsnYNz3RGnqzefHA47wQpKrrdTIwXQ="
+                },
+                {
+                    "name": "syft:metadata:mainModule",
+                    "value": "github.com/bomctl/bomctl"
+                }
+            ]
+        },
+        {
+            "bom-ref": "pkg:golang/github.com/kevinburke/ssh_config@v1.2.0?package-id=ffb77012bf13de50",
+            "type": "library",
+            "name": "github.com/kevinburke/ssh_config",
+            "version": "v1.2.0",
+            "cpe": "cpe:2.3:a:kevinburke:ssh-config:v1.2.0:*:*:*:*:*:*:*",
+            "purl": "pkg:golang/github.com/kevinburke/ssh_config@v1.2.0",
+            "properties": [
+                {
+                    "name": "syft:package:foundBy",
+                    "value": "go-module-binary-cataloger"
+                },
+                {
+                    "name": "syft:package:language",
+                    "value": "go"
+                },
+                {
+                    "name": "syft:package:type",
+                    "value": "go-module"
+                },
+                {
+                    "name": "syft:package:metadataType",
+                    "value": "go-module-buildinfo-entry"
+                },
+                {
+                    "name": "syft:cpe23",
+                    "value": "cpe:2.3:a:kevinburke:ssh_config:v1.2.0:*:*:*:*:*:*:*"
+                },
+                {
+                    "name": "syft:location:0:path",
+                    "value": "bomctl"
+                },
+                {
+                    "name": "syft:metadata:architecture",
+                    "value": "amd64"
+                },
+                {
+                    "name": "syft:metadata:goCompiledVersion",
+                    "value": "go1.22.2"
+                },
+                {
+                    "name": "syft:metadata:h1Digest",
+                    "value": "h1:x584FjTGwHzMwvHx18PXxbBVzfnxogHaAReU4gf13a4="
+                },
+                {
+                    "name": "syft:metadata:mainModule",
+                    "value": "github.com/bomctl/bomctl"
+                }
+            ]
+        },
+        {
+            "bom-ref": "pkg:golang/github.com/lib/pq@v1.10.9?package-id=06769d35115d66d9",
+            "type": "library",
+            "name": "github.com/lib/pq",
+            "version": "v1.10.9",
+            "cpe": "cpe:2.3:a:lib:pq:v1.10.9:*:*:*:*:*:*:*",
+            "purl": "pkg:golang/github.com/lib/pq@v1.10.9",
+            "properties": [
+                {
+                    "name": "syft:package:foundBy",
+                    "value": "go-module-binary-cataloger"
+                },
+                {
+                    "name": "syft:package:language",
+                    "value": "go"
+                },
+                {
+                    "name": "syft:package:type",
+                    "value": "go-module"
+                },
+                {
+                    "name": "syft:package:metadataType",
+                    "value": "go-module-buildinfo-entry"
+                },
+                {
+                    "name": "syft:location:0:path",
+                    "value": "bomctl"
+                },
+                {
+                    "name": "syft:metadata:architecture",
+                    "value": "amd64"
+                },
+                {
+                    "name": "syft:metadata:goCompiledVersion",
+                    "value": "go1.22.2"
+                },
+                {
+                    "name": "syft:metadata:h1Digest",
+                    "value": "h1:YXG7RB+JIjhP29X+OtkiDnYaXQwpS4JEWq7dtCCRUEw="
+                },
+                {
+                    "name": "syft:metadata:mainModule",
+                    "value": "github.com/bomctl/bomctl"
+                }
+            ]
+        },
+        {
+            "bom-ref": "pkg:golang/github.com/lucasb-eyer/go-colorful@v1.2.0?package-id=7a6a74f423228a15",
+            "type": "library",
+            "name": "github.com/lucasb-eyer/go-colorful",
+            "version": "v1.2.0",
+            "cpe": "cpe:2.3:a:lucasb-eyer:go-colorful:v1.2.0:*:*:*:*:*:*:*",
+            "purl": "pkg:golang/github.com/lucasb-eyer/go-colorful@v1.2.0",
+            "properties": [
+                {
+                    "name": "syft:package:foundBy",
+                    "value": "go-module-binary-cataloger"
+                },
+                {
+                    "name": "syft:package:language",
+                    "value": "go"
+                },
+                {
+                    "name": "syft:package:type",
+                    "value": "go-module"
+                },
+                {
+                    "name": "syft:package:metadataType",
+                    "value": "go-module-buildinfo-entry"
+                },
+                {
+                    "name": "syft:cpe23",
+                    "value": "cpe:2.3:a:lucasb-eyer:go_colorful:v1.2.0:*:*:*:*:*:*:*"
+                },
+                {
+                    "name": "syft:cpe23",
+                    "value": "cpe:2.3:a:lucasb_eyer:go-colorful:v1.2.0:*:*:*:*:*:*:*"
+                },
+                {
+                    "name": "syft:cpe23",
+                    "value": "cpe:2.3:a:lucasb_eyer:go_colorful:v1.2.0:*:*:*:*:*:*:*"
+                },
+                {
+                    "name": "syft:cpe23",
+                    "value": "cpe:2.3:a:lucasb:go-colorful:v1.2.0:*:*:*:*:*:*:*"
+                },
+                {
+                    "name": "syft:cpe23",
+                    "value": "cpe:2.3:a:lucasb:go_colorful:v1.2.0:*:*:*:*:*:*:*"
+                },
+                {
+                    "name": "syft:location:0:path",
+                    "value": "bomctl"
+                },
+                {
+                    "name": "syft:metadata:architecture",
+                    "value": "amd64"
+                },
+                {
+                    "name": "syft:metadata:goCompiledVersion",
+                    "value": "go1.22.2"
+                },
+                {
+                    "name": "syft:metadata:h1Digest",
+                    "value": "h1:1nnpGOrhyZZuNyfu1QjKiUICQ74+3FNCN69Aj6K7nkY="
+                },
+                {
+                    "name": "syft:metadata:mainModule",
+                    "value": "github.com/bomctl/bomctl"
+                }
+            ]
+        },
+        {
+            "bom-ref": "pkg:golang/github.com/magiconair/properties@v1.8.7?package-id=d714fb67663a9a30",
+            "type": "library",
+            "name": "github.com/magiconair/properties",
+            "version": "v1.8.7",
+            "cpe": "cpe:2.3:a:magiconair:properties:v1.8.7:*:*:*:*:*:*:*",
+            "purl": "pkg:golang/github.com/magiconair/properties@v1.8.7",
+            "properties": [
+                {
+                    "name": "syft:package:foundBy",
+                    "value": "go-module-binary-cataloger"
+                },
+                {
+                    "name": "syft:package:language",
+                    "value": "go"
+                },
+                {
+                    "name": "syft:package:type",
+                    "value": "go-module"
+                },
+                {
+                    "name": "syft:package:metadataType",
+                    "value": "go-module-buildinfo-entry"
+                },
+                {
+                    "name": "syft:location:0:path",
+                    "value": "bomctl"
+                },
+                {
+                    "name": "syft:metadata:architecture",
+                    "value": "amd64"
+                },
+                {
+                    "name": "syft:metadata:goCompiledVersion",
+                    "value": "go1.22.2"
+                },
+                {
+                    "name": "syft:metadata:h1Digest",
+                    "value": "h1:IeQXZAiQcpL9mgcAe1Nu6cX9LLw6ExEHKjN0VQdvPDY="
+                },
+                {
+                    "name": "syft:metadata:mainModule",
+                    "value": "github.com/bomctl/bomctl"
+                }
+            ]
+        },
+        {
+            "bom-ref": "pkg:golang/github.com/mattn/go-isatty@v0.0.20?package-id=0866e8bfeb9cd72a",
+            "type": "library",
+            "name": "github.com/mattn/go-isatty",
+            "version": "v0.0.20",
+            "cpe": "cpe:2.3:a:mattn:go-isatty:v0.0.20:*:*:*:*:*:*:*",
+            "purl": "pkg:golang/github.com/mattn/go-isatty@v0.0.20",
+            "properties": [
+                {
+                    "name": "syft:package:foundBy",
+                    "value": "go-module-binary-cataloger"
+                },
+                {
+                    "name": "syft:package:language",
+                    "value": "go"
+                },
+                {
+                    "name": "syft:package:type",
+                    "value": "go-module"
+                },
+                {
+                    "name": "syft:package:metadataType",
+                    "value": "go-module-buildinfo-entry"
+                },
+                {
+                    "name": "syft:cpe23",
+                    "value": "cpe:2.3:a:mattn:go_isatty:v0.0.20:*:*:*:*:*:*:*"
+                },
+                {
+                    "name": "syft:location:0:path",
+                    "value": "bomctl"
+                },
+                {
+                    "name": "syft:metadata:architecture",
+                    "value": "amd64"
+                },
+                {
+                    "name": "syft:metadata:goCompiledVersion",
+                    "value": "go1.22.2"
+                },
+                {
+                    "name": "syft:metadata:h1Digest",
+                    "value": "h1:xfD0iDuEKnDkl03q4limB+vH+GxLEtL/jb4xVJSWWEY="
+                },
+                {
+                    "name": "syft:metadata:mainModule",
+                    "value": "github.com/bomctl/bomctl"
+                }
+            ]
+        },
+        {
+            "bom-ref": "pkg:golang/github.com/mattn/go-runewidth@v0.0.15?package-id=4f779842004a2bf7",
+            "type": "library",
+            "name": "github.com/mattn/go-runewidth",
+            "version": "v0.0.15",
+            "cpe": "cpe:2.3:a:mattn:go-runewidth:v0.0.15:*:*:*:*:*:*:*",
+            "purl": "pkg:golang/github.com/mattn/go-runewidth@v0.0.15",
+            "properties": [
+                {
+                    "name": "syft:package:foundBy",
+                    "value": "go-module-binary-cataloger"
+                },
+                {
+                    "name": "syft:package:language",
+                    "value": "go"
+                },
+                {
+                    "name": "syft:package:type",
+                    "value": "go-module"
+                },
+                {
+                    "name": "syft:package:metadataType",
+                    "value": "go-module-buildinfo-entry"
+                },
+                {
+                    "name": "syft:cpe23",
+                    "value": "cpe:2.3:a:mattn:go_runewidth:v0.0.15:*:*:*:*:*:*:*"
+                },
+                {
+                    "name": "syft:location:0:path",
+                    "value": "bomctl"
+                },
+                {
+                    "name": "syft:metadata:architecture",
+                    "value": "amd64"
+                },
+                {
+                    "name": "syft:metadata:goCompiledVersion",
+                    "value": "go1.22.2"
+                },
+                {
+                    "name": "syft:metadata:h1Digest",
+                    "value": "h1:UNAjwbU9l54TA3KzvqLGxwWjHmMgBUVhBiTjelZgg3U="
+                },
+                {
+                    "name": "syft:metadata:mainModule",
+                    "value": "github.com/bomctl/bomctl"
+                }
+            ]
+        },
+        {
+            "bom-ref": "pkg:golang/github.com/mitchellh/mapstructure@v1.5.0?package-id=e07d5b8c3c49a172",
+            "type": "library",
+            "name": "github.com/mitchellh/mapstructure",
+            "version": "v1.5.0",
+            "cpe": "cpe:2.3:a:mitchellh:mapstructure:v1.5.0:*:*:*:*:*:*:*",
+            "purl": "pkg:golang/github.com/mitchellh/mapstructure@v1.5.0",
+            "properties": [
+                {
+                    "name": "syft:package:foundBy",
+                    "value": "go-module-binary-cataloger"
+                },
+                {
+                    "name": "syft:package:language",
+                    "value": "go"
+                },
+                {
+                    "name": "syft:package:type",
+                    "value": "go-module"
+                },
+                {
+                    "name": "syft:package:metadataType",
+                    "value": "go-module-buildinfo-entry"
+                },
+                {
+                    "name": "syft:location:0:path",
+                    "value": "bomctl"
+                },
+                {
+                    "name": "syft:metadata:architecture",
+                    "value": "amd64"
+                },
+                {
+                    "name": "syft:metadata:goCompiledVersion",
+                    "value": "go1.22.2"
+                },
+                {
+                    "name": "syft:metadata:h1Digest",
+                    "value": "h1:jeMsZIYE/09sWLaz43PL7Gy6RuMjD2eJVyuac5Z2hdY="
+                },
+                {
+                    "name": "syft:metadata:mainModule",
+                    "value": "github.com/bomctl/bomctl"
+                }
+            ]
+        },
+        {
+            "bom-ref": "pkg:golang/github.com/muesli/reflow@v0.3.0?package-id=834173e90e256c52",
+            "type": "library",
+            "name": "github.com/muesli/reflow",
+            "version": "v0.3.0",
+            "cpe": "cpe:2.3:a:muesli:reflow:v0.3.0:*:*:*:*:*:*:*",
+            "purl": "pkg:golang/github.com/muesli/reflow@v0.3.0",
+            "properties": [
+                {
+                    "name": "syft:package:foundBy",
+                    "value": "go-module-binary-cataloger"
+                },
+                {
+                    "name": "syft:package:language",
+                    "value": "go"
+                },
+                {
+                    "name": "syft:package:type",
+                    "value": "go-module"
+                },
+                {
+                    "name": "syft:package:metadataType",
+                    "value": "go-module-buildinfo-entry"
+                },
+                {
+                    "name": "syft:location:0:path",
+                    "value": "bomctl"
+                },
+                {
+                    "name": "syft:metadata:architecture",
+                    "value": "amd64"
+                },
+                {
+                    "name": "syft:metadata:goCompiledVersion",
+                    "value": "go1.22.2"
+                },
+                {
+                    "name": "syft:metadata:h1Digest",
+                    "value": "h1:IFsN6K9NfGtjeggFP+68I4chLZV2yIKsXJFNZ+eWh6s="
+                },
+                {
+                    "name": "syft:metadata:mainModule",
+                    "value": "github.com/bomctl/bomctl"
+                }
+            ]
+        },
+        {
+            "bom-ref": "pkg:golang/github.com/muesli/termenv@v0.15.2?package-id=ae1b1c57f2516141",
+            "type": "library",
+            "name": "github.com/muesli/termenv",
+            "version": "v0.15.2",
+            "cpe": "cpe:2.3:a:muesli:termenv:v0.15.2:*:*:*:*:*:*:*",
+            "purl": "pkg:golang/github.com/muesli/termenv@v0.15.2",
+            "properties": [
+                {
+                    "name": "syft:package:foundBy",
+                    "value": "go-module-binary-cataloger"
+                },
+                {
+                    "name": "syft:package:language",
+                    "value": "go"
+                },
+                {
+                    "name": "syft:package:type",
+                    "value": "go-module"
+                },
+                {
+                    "name": "syft:package:metadataType",
+                    "value": "go-module-buildinfo-entry"
+                },
+                {
+                    "name": "syft:location:0:path",
+                    "value": "bomctl"
+                },
+                {
+                    "name": "syft:metadata:architecture",
+                    "value": "amd64"
+                },
+                {
+                    "name": "syft:metadata:goCompiledVersion",
+                    "value": "go1.22.2"
+                },
+                {
+                    "name": "syft:metadata:h1Digest",
+                    "value": "h1:GohcuySI0QmI3wN8Ok9PtKGkgkFIk7y6Vpb5PvrY+Wo="
+                },
+                {
+                    "name": "syft:metadata:mainModule",
+                    "value": "github.com/bomctl/bomctl"
+                }
+            ]
+        },
+        {
+            "bom-ref": "pkg:golang/github.com/opencontainers/go-digest@v1.0.0?package-id=6d33689969473553",
+            "type": "library",
+            "name": "github.com/opencontainers/go-digest",
+            "version": "v1.0.0",
+            "cpe": "cpe:2.3:a:opencontainers:go-digest:v1.0.0:*:*:*:*:*:*:*",
+            "purl": "pkg:golang/github.com/opencontainers/go-digest@v1.0.0",
+            "properties": [
+                {
+                    "name": "syft:package:foundBy",
+                    "value": "go-module-binary-cataloger"
+                },
+                {
+                    "name": "syft:package:language",
+                    "value": "go"
+                },
+                {
+                    "name": "syft:package:type",
+                    "value": "go-module"
+                },
+                {
+                    "name": "syft:package:metadataType",
+                    "value": "go-module-buildinfo-entry"
+                },
+                {
+                    "name": "syft:cpe23",
+                    "value": "cpe:2.3:a:opencontainers:go_digest:v1.0.0:*:*:*:*:*:*:*"
+                },
+                {
+                    "name": "syft:location:0:path",
+                    "value": "bomctl"
+                },
+                {
+                    "name": "syft:metadata:architecture",
+                    "value": "amd64"
+                },
+                {
+                    "name": "syft:metadata:goCompiledVersion",
+                    "value": "go1.22.2"
+                },
+                {
+                    "name": "syft:metadata:h1Digest",
+                    "value": "h1:apOUWs51W5PlhuyGyz9FCeeBIOUDA/6nW8Oi/yOhh5U="
+                },
+                {
+                    "name": "syft:metadata:mainModule",
+                    "value": "github.com/bomctl/bomctl"
+                }
+            ]
+        },
+        {
+            "bom-ref": "pkg:golang/github.com/opencontainers/image-spec@v1.1.0?package-id=4c0d85459b6e2bea",
+            "type": "library",
+            "name": "github.com/opencontainers/image-spec",
+            "version": "v1.1.0",
+            "cpe": "cpe:2.3:a:opencontainers:image-spec:v1.1.0:*:*:*:*:*:*:*",
+            "purl": "pkg:golang/github.com/opencontainers/image-spec@v1.1.0",
+            "properties": [
+                {
+                    "name": "syft:package:foundBy",
+                    "value": "go-module-binary-cataloger"
+                },
+                {
+                    "name": "syft:package:language",
+                    "value": "go"
+                },
+                {
+                    "name": "syft:package:type",
+                    "value": "go-module"
+                },
+                {
+                    "name": "syft:package:metadataType",
+                    "value": "go-module-buildinfo-entry"
+                },
+                {
+                    "name": "syft:cpe23",
+                    "value": "cpe:2.3:a:opencontainers:image_spec:v1.1.0:*:*:*:*:*:*:*"
+                },
+                {
+                    "name": "syft:location:0:path",
+                    "value": "bomctl"
+                },
+                {
+                    "name": "syft:metadata:architecture",
+                    "value": "amd64"
+                },
+                {
+                    "name": "syft:metadata:goCompiledVersion",
+                    "value": "go1.22.2"
+                },
+                {
+                    "name": "syft:metadata:h1Digest",
+                    "value": "h1:8SG7/vwALn54lVB/0yZ/MMwhFrPYtpEHQb2IpWsCzug="
+                },
+                {
+                    "name": "syft:metadata:mainModule",
+                    "value": "github.com/bomctl/bomctl"
+                }
+            ]
+        },
+        {
+            "bom-ref": "pkg:golang/github.com/pelletier/go-toml@v2.0.8?package-id=5d9b5ba56cf0ad9a#v2",
+            "type": "library",
+            "name": "github.com/pelletier/go-toml/v2",
+            "version": "v2.0.8",
+            "cpe": "cpe:2.3:a:pelletier:go-toml\\/v2:v2.0.8:*:*:*:*:*:*:*",
+            "purl": "pkg:golang/github.com/pelletier/go-toml@v2.0.8#v2",
+            "properties": [
+                {
+                    "name": "syft:package:foundBy",
+                    "value": "go-module-binary-cataloger"
+                },
+                {
+                    "name": "syft:package:language",
+                    "value": "go"
+                },
+                {
+                    "name": "syft:package:type",
+                    "value": "go-module"
+                },
+                {
+                    "name": "syft:package:metadataType",
+                    "value": "go-module-buildinfo-entry"
+                },
+                {
+                    "name": "syft:cpe23",
+                    "value": "cpe:2.3:a:pelletier:go_toml\\/v2:v2.0.8:*:*:*:*:*:*:*"
+                },
+                {
+                    "name": "syft:location:0:path",
+                    "value": "bomctl"
+                },
+                {
+                    "name": "syft:metadata:architecture",
+                    "value": "amd64"
+                },
+                {
+                    "name": "syft:metadata:goCompiledVersion",
+                    "value": "go1.22.2"
+                },
+                {
+                    "name": "syft:metadata:h1Digest",
+                    "value": "h1:0ctb6s9mE31h0/lhu+J6OPmVeDxJn+kYnJc2jZR9tGQ="
+                },
+                {
+                    "name": "syft:metadata:mainModule",
+                    "value": "github.com/bomctl/bomctl"
+                }
+            ]
+        },
+        {
+            "bom-ref": "pkg:golang/github.com/pjbgf/sha1cd@v0.3.0?package-id=70840ef62cb1b703",
+            "type": "library",
+            "name": "github.com/pjbgf/sha1cd",
+            "version": "v0.3.0",
+            "cpe": "cpe:2.3:a:pjbgf:sha1cd:v0.3.0:*:*:*:*:*:*:*",
+            "purl": "pkg:golang/github.com/pjbgf/sha1cd@v0.3.0",
+            "properties": [
+                {
+                    "name": "syft:package:foundBy",
+                    "value": "go-module-binary-cataloger"
+                },
+                {
+                    "name": "syft:package:language",
+                    "value": "go"
+                },
+                {
+                    "name": "syft:package:type",
+                    "value": "go-module"
+                },
+                {
+                    "name": "syft:package:metadataType",
+                    "value": "go-module-buildinfo-entry"
+                },
+                {
+                    "name": "syft:location:0:path",
+                    "value": "bomctl"
+                },
+                {
+                    "name": "syft:metadata:architecture",
+                    "value": "amd64"
+                },
+                {
+                    "name": "syft:metadata:goCompiledVersion",
+                    "value": "go1.22.2"
+                },
+                {
+                    "name": "syft:metadata:h1Digest",
+                    "value": "h1:4D5XXmUUBUl/xQ6IjCkEAbqXskkq/4O7LmGn0AqMDs4="
+                },
+                {
+                    "name": "syft:metadata:mainModule",
+                    "value": "github.com/bomctl/bomctl"
+                }
+            ]
+        },
+        {
+            "bom-ref": "pkg:golang/github.com/remyoudompheng/bigfft@v0.0.0-20230129092748-24d4a6f8daec?package-id=822114af3dd10b25",
+            "type": "library",
+            "name": "github.com/remyoudompheng/bigfft",
+            "version": "v0.0.0-20230129092748-24d4a6f8daec",
+            "cpe": "cpe:2.3:a:remyoudompheng:bigfft:v0.0.0-20230129092748-24d4a6f8daec:*:*:*:*:*:*:*",
+            "purl": "pkg:golang/github.com/remyoudompheng/bigfft@v0.0.0-20230129092748-24d4a6f8daec",
+            "properties": [
+                {
+                    "name": "syft:package:foundBy",
+                    "value": "go-module-binary-cataloger"
+                },
+                {
+                    "name": "syft:package:language",
+                    "value": "go"
+                },
+                {
+                    "name": "syft:package:type",
+                    "value": "go-module"
+                },
+                {
+                    "name": "syft:package:metadataType",
+                    "value": "go-module-buildinfo-entry"
+                },
+                {
+                    "name": "syft:location:0:path",
+                    "value": "bomctl"
+                },
+                {
+                    "name": "syft:metadata:architecture",
+                    "value": "amd64"
+                },
+                {
+                    "name": "syft:metadata:goCompiledVersion",
+                    "value": "go1.22.2"
+                },
+                {
+                    "name": "syft:metadata:h1Digest",
+                    "value": "h1:W09IVJc94icq4NjY3clb7Lk8O1qJ8BdBEF8z0ibU0rE="
+                },
+                {
+                    "name": "syft:metadata:mainModule",
+                    "value": "github.com/bomctl/bomctl"
+                }
+            ]
+        },
+        {
+            "bom-ref": "pkg:golang/github.com/rivo/uniseg@v0.2.0?package-id=b336898b0d71574e",
+            "type": "library",
+            "name": "github.com/rivo/uniseg",
+            "version": "v0.2.0",
+            "cpe": "cpe:2.3:a:rivo:uniseg:v0.2.0:*:*:*:*:*:*:*",
+            "purl": "pkg:golang/github.com/rivo/uniseg@v0.2.0",
+            "properties": [
+                {
+                    "name": "syft:package:foundBy",
+                    "value": "go-module-binary-cataloger"
+                },
+                {
+                    "name": "syft:package:language",
+                    "value": "go"
+                },
+                {
+                    "name": "syft:package:type",
+                    "value": "go-module"
+                },
+                {
+                    "name": "syft:package:metadataType",
+                    "value": "go-module-buildinfo-entry"
+                },
+                {
+                    "name": "syft:location:0:path",
+                    "value": "bomctl"
+                },
+                {
+                    "name": "syft:metadata:architecture",
+                    "value": "amd64"
+                },
+                {
+                    "name": "syft:metadata:goCompiledVersion",
+                    "value": "go1.22.2"
+                },
+                {
+                    "name": "syft:metadata:h1Digest",
+                    "value": "h1:S1pD9weZBuJdFmowNwbpi7BJ8TNftyUImj/0WQi72jY="
+                },
+                {
+                    "name": "syft:metadata:mainModule",
+                    "value": "github.com/bomctl/bomctl"
+                }
+            ]
+        },
+        {
+            "bom-ref": "pkg:golang/github.com/sergi/go-diff@v1.1.0?package-id=dbec454a7bf54682",
+            "type": "library",
+            "name": "github.com/sergi/go-diff",
+            "version": "v1.1.0",
+            "cpe": "cpe:2.3:a:sergi:go-diff:v1.1.0:*:*:*:*:*:*:*",
+            "purl": "pkg:golang/github.com/sergi/go-diff@v1.1.0",
+            "properties": [
+                {
+                    "name": "syft:package:foundBy",
+                    "value": "go-module-binary-cataloger"
+                },
+                {
+                    "name": "syft:package:language",
+                    "value": "go"
+                },
+                {
+                    "name": "syft:package:type",
+                    "value": "go-module"
+                },
+                {
+                    "name": "syft:package:metadataType",
+                    "value": "go-module-buildinfo-entry"
+                },
+                {
+                    "name": "syft:cpe23",
+                    "value": "cpe:2.3:a:sergi:go_diff:v1.1.0:*:*:*:*:*:*:*"
+                },
+                {
+                    "name": "syft:location:0:path",
+                    "value": "bomctl"
+                },
+                {
+                    "name": "syft:metadata:architecture",
+                    "value": "amd64"
+                },
+                {
+                    "name": "syft:metadata:goCompiledVersion",
+                    "value": "go1.22.2"
+                },
+                {
+                    "name": "syft:metadata:h1Digest",
+                    "value": "h1:we8PVUC3FE2uYfodKH/nBHMSetSfHDR6scGdBi+erh0="
+                },
+                {
+                    "name": "syft:metadata:mainModule",
+                    "value": "github.com/bomctl/bomctl"
+                }
+            ]
+        },
+        {
+            "bom-ref": "pkg:golang/github.com/sirupsen/logrus@v1.9.3?package-id=5264e6e3df8e6fac",
+            "type": "library",
+            "name": "github.com/sirupsen/logrus",
+            "version": "v1.9.3",
+            "cpe": "cpe:2.3:a:sirupsen:logrus:v1.9.3:*:*:*:*:*:*:*",
+            "purl": "pkg:golang/github.com/sirupsen/logrus@v1.9.3",
+            "properties": [
+                {
+                    "name": "syft:package:foundBy",
+                    "value": "go-module-binary-cataloger"
+                },
+                {
+                    "name": "syft:package:language",
+                    "value": "go"
+                },
+                {
+                    "name": "syft:package:type",
+                    "value": "go-module"
+                },
+                {
+                    "name": "syft:package:metadataType",
+                    "value": "go-module-buildinfo-entry"
+                },
+                {
+                    "name": "syft:location:0:path",
+                    "value": "bomctl"
+                },
+                {
+                    "name": "syft:metadata:architecture",
+                    "value": "amd64"
+                },
+                {
+                    "name": "syft:metadata:goCompiledVersion",
+                    "value": "go1.22.2"
+                },
+                {
+                    "name": "syft:metadata:h1Digest",
+                    "value": "h1:dueUQJ1C2q9oE3F7wvmSGAaVtTmUizReu6fjN8uqzbQ="
+                },
+                {
+                    "name": "syft:metadata:mainModule",
+                    "value": "github.com/bomctl/bomctl"
+                }
+            ]
+        },
+        {
+            "bom-ref": "pkg:golang/github.com/skeema/knownhosts@v1.2.1?package-id=cd78fb6dfb1fac08",
+            "type": "library",
+            "name": "github.com/skeema/knownhosts",
+            "version": "v1.2.1",
+            "cpe": "cpe:2.3:a:skeema:knownhosts:v1.2.1:*:*:*:*:*:*:*",
+            "purl": "pkg:golang/github.com/skeema/knownhosts@v1.2.1",
+            "properties": [
+                {
+                    "name": "syft:package:foundBy",
+                    "value": "go-module-binary-cataloger"
+                },
+                {
+                    "name": "syft:package:language",
+                    "value": "go"
+                },
+                {
+                    "name": "syft:package:type",
+                    "value": "go-module"
+                },
+                {
+                    "name": "syft:package:metadataType",
+                    "value": "go-module-buildinfo-entry"
+                },
+                {
+                    "name": "syft:location:0:path",
+                    "value": "bomctl"
+                },
+                {
+                    "name": "syft:metadata:architecture",
+                    "value": "amd64"
+                },
+                {
+                    "name": "syft:metadata:goCompiledVersion",
+                    "value": "go1.22.2"
+                },
+                {
+                    "name": "syft:metadata:h1Digest",
+                    "value": "h1:SHWdIUa82uGZz+F+47k8SY4QhhI291cXCpopT1lK2AQ="
+                },
+                {
+                    "name": "syft:metadata:mainModule",
+                    "value": "github.com/bomctl/bomctl"
+                }
+            ]
+        },
+        {
+            "bom-ref": "pkg:golang/github.com/spdx/tools-golang@v0.5.3?package-id=950bc545244a6f3f",
+            "type": "library",
+            "name": "github.com/spdx/tools-golang",
+            "version": "v0.5.3",
+            "cpe": "cpe:2.3:a:spdx:tools-golang:v0.5.3:*:*:*:*:*:*:*",
+            "purl": "pkg:golang/github.com/spdx/tools-golang@v0.5.3",
+            "properties": [
+                {
+                    "name": "syft:package:foundBy",
+                    "value": "go-module-binary-cataloger"
+                },
+                {
+                    "name": "syft:package:language",
+                    "value": "go"
+                },
+                {
+                    "name": "syft:package:type",
+                    "value": "go-module"
+                },
+                {
+                    "name": "syft:package:metadataType",
+                    "value": "go-module-buildinfo-entry"
+                },
+                {
+                    "name": "syft:cpe23",
+                    "value": "cpe:2.3:a:spdx:tools_golang:v0.5.3:*:*:*:*:*:*:*"
+                },
+                {
+                    "name": "syft:location:0:path",
+                    "value": "bomctl"
+                },
+                {
+                    "name": "syft:metadata:architecture",
+                    "value": "amd64"
+                },
+                {
+                    "name": "syft:metadata:goCompiledVersion",
+                    "value": "go1.22.2"
+                },
+                {
+                    "name": "syft:metadata:h1Digest",
+                    "value": "h1:ialnHeEYUC4+hkm5vJm4qz2x+oEJbS0mAMFrNXdQraY="
+                },
+                {
+                    "name": "syft:metadata:mainModule",
+                    "value": "github.com/bomctl/bomctl"
+                }
+            ]
+        },
+        {
+            "bom-ref": "pkg:golang/github.com/spf13/afero@v1.9.5?package-id=f6bce72ddeb0aa92",
+            "type": "library",
+            "name": "github.com/spf13/afero",
+            "version": "v1.9.5",
+            "cpe": "cpe:2.3:a:spf13:afero:v1.9.5:*:*:*:*:*:*:*",
+            "purl": "pkg:golang/github.com/spf13/afero@v1.9.5",
+            "properties": [
+                {
+                    "name": "syft:package:foundBy",
+                    "value": "go-module-binary-cataloger"
+                },
+                {
+                    "name": "syft:package:language",
+                    "value": "go"
+                },
+                {
+                    "name": "syft:package:type",
+                    "value": "go-module"
+                },
+                {
+                    "name": "syft:package:metadataType",
+                    "value": "go-module-buildinfo-entry"
+                },
+                {
+                    "name": "syft:location:0:path",
+                    "value": "bomctl"
+                },
+                {
+                    "name": "syft:metadata:architecture",
+                    "value": "amd64"
+                },
+                {
+                    "name": "syft:metadata:goCompiledVersion",
+                    "value": "go1.22.2"
+                },
+                {
+                    "name": "syft:metadata:h1Digest",
+                    "value": "h1:stMpOSZFs//0Lv29HduCmli3GUfpFoF3Y1Q/aXj/wVM="
+                },
+                {
+                    "name": "syft:metadata:mainModule",
+                    "value": "github.com/bomctl/bomctl"
+                }
+            ]
+        },
+        {
+            "bom-ref": "pkg:golang/github.com/spf13/cast@v1.5.1?package-id=f80abd1802eee1de",
+            "type": "library",
+            "name": "github.com/spf13/cast",
+            "version": "v1.5.1",
+            "cpe": "cpe:2.3:a:spf13:cast:v1.5.1:*:*:*:*:*:*:*",
+            "purl": "pkg:golang/github.com/spf13/cast@v1.5.1",
+            "properties": [
+                {
+                    "name": "syft:package:foundBy",
+                    "value": "go-module-binary-cataloger"
+                },
+                {
+                    "name": "syft:package:language",
+                    "value": "go"
+                },
+                {
+                    "name": "syft:package:type",
+                    "value": "go-module"
+                },
+                {
+                    "name": "syft:package:metadataType",
+                    "value": "go-module-buildinfo-entry"
+                },
+                {
+                    "name": "syft:location:0:path",
+                    "value": "bomctl"
+                },
+                {
+                    "name": "syft:metadata:architecture",
+                    "value": "amd64"
+                },
+                {
+                    "name": "syft:metadata:goCompiledVersion",
+                    "value": "go1.22.2"
+                },
+                {
+                    "name": "syft:metadata:h1Digest",
+                    "value": "h1:R+kOtfhWQE6TVQzY+4D7wJLBgkdVasCEFxSUBYBYIlA="
+                },
+                {
+                    "name": "syft:metadata:mainModule",
+                    "value": "github.com/bomctl/bomctl"
+                }
+            ]
+        },
+        {
+            "bom-ref": "pkg:golang/github.com/spf13/cobra@v1.8.0?package-id=1cf68e3810df548a",
+            "type": "library",
+            "name": "github.com/spf13/cobra",
+            "version": "v1.8.0",
+            "cpe": "cpe:2.3:a:spf13:cobra:v1.8.0:*:*:*:*:*:*:*",
+            "purl": "pkg:golang/github.com/spf13/cobra@v1.8.0",
+            "properties": [
+                {
+                    "name": "syft:package:foundBy",
+                    "value": "go-module-binary-cataloger"
+                },
+                {
+                    "name": "syft:package:language",
+                    "value": "go"
+                },
+                {
+                    "name": "syft:package:type",
+                    "value": "go-module"
+                },
+                {
+                    "name": "syft:package:metadataType",
+                    "value": "go-module-buildinfo-entry"
+                },
+                {
+                    "name": "syft:location:0:path",
+                    "value": "bomctl"
+                },
+                {
+                    "name": "syft:metadata:architecture",
+                    "value": "amd64"
+                },
+                {
+                    "name": "syft:metadata:goCompiledVersion",
+                    "value": "go1.22.2"
+                },
+                {
+                    "name": "syft:metadata:h1Digest",
+                    "value": "h1:7aJaZx1B85qltLMc546zn58BxxfZdR/W22ej9CFoEf0="
+                },
+                {
+                    "name": "syft:metadata:mainModule",
+                    "value": "github.com/bomctl/bomctl"
+                }
+            ]
+        },
+        {
+            "bom-ref": "pkg:golang/github.com/spf13/jwalterweatherman@v1.1.0?package-id=953ae8b4368bae4a",
+            "type": "library",
+            "name": "github.com/spf13/jwalterweatherman",
+            "version": "v1.1.0",
+            "cpe": "cpe:2.3:a:spf13:jwalterweatherman:v1.1.0:*:*:*:*:*:*:*",
+            "purl": "pkg:golang/github.com/spf13/jwalterweatherman@v1.1.0",
+            "properties": [
+                {
+                    "name": "syft:package:foundBy",
+                    "value": "go-module-binary-cataloger"
+                },
+                {
+                    "name": "syft:package:language",
+                    "value": "go"
+                },
+                {
+                    "name": "syft:package:type",
+                    "value": "go-module"
+                },
+                {
+                    "name": "syft:package:metadataType",
+                    "value": "go-module-buildinfo-entry"
+                },
+                {
+                    "name": "syft:location:0:path",
+                    "value": "bomctl"
+                },
+                {
+                    "name": "syft:metadata:architecture",
+                    "value": "amd64"
+                },
+                {
+                    "name": "syft:metadata:goCompiledVersion",
+                    "value": "go1.22.2"
+                },
+                {
+                    "name": "syft:metadata:h1Digest",
+                    "value": "h1:ue6voC5bR5F8YxI5S67j9i582FU4Qvo2bmqnqMYADFk="
+                },
+                {
+                    "name": "syft:metadata:mainModule",
+                    "value": "github.com/bomctl/bomctl"
+                }
+            ]
+        },
+        {
+            "bom-ref": "pkg:golang/github.com/spf13/pflag@v1.0.5?package-id=44571927d6ab364d",
+            "type": "library",
+            "name": "github.com/spf13/pflag",
+            "version": "v1.0.5",
+            "cpe": "cpe:2.3:a:spf13:pflag:v1.0.5:*:*:*:*:*:*:*",
+            "purl": "pkg:golang/github.com/spf13/pflag@v1.0.5",
+            "properties": [
+                {
+                    "name": "syft:package:foundBy",
+                    "value": "go-module-binary-cataloger"
+                },
+                {
+                    "name": "syft:package:language",
+                    "value": "go"
+                },
+                {
+                    "name": "syft:package:type",
+                    "value": "go-module"
+                },
+                {
+                    "name": "syft:package:metadataType",
+                    "value": "go-module-buildinfo-entry"
+                },
+                {
+                    "name": "syft:location:0:path",
+                    "value": "bomctl"
+                },
+                {
+                    "name": "syft:metadata:architecture",
+                    "value": "amd64"
+                },
+                {
+                    "name": "syft:metadata:goCompiledVersion",
+                    "value": "go1.22.2"
+                },
+                {
+                    "name": "syft:metadata:h1Digest",
+                    "value": "h1:iy+VFUOCP1a+8yFto/drg2CJ5u0yRoB7fZw3DKv/JXA="
+                },
+                {
+                    "name": "syft:metadata:mainModule",
+                    "value": "github.com/bomctl/bomctl"
+                }
+            ]
+        },
+        {
+            "bom-ref": "pkg:golang/github.com/spf13/viper@v1.16.0?package-id=06dfcd27c4f91a35",
+            "type": "library",
+            "name": "github.com/spf13/viper",
+            "version": "v1.16.0",
+            "cpe": "cpe:2.3:a:spf13:viper:v1.16.0:*:*:*:*:*:*:*",
+            "purl": "pkg:golang/github.com/spf13/viper@v1.16.0",
+            "properties": [
+                {
+                    "name": "syft:package:foundBy",
+                    "value": "go-module-binary-cataloger"
+                },
+                {
+                    "name": "syft:package:language",
+                    "value": "go"
+                },
+                {
+                    "name": "syft:package:type",
+                    "value": "go-module"
+                },
+                {
+                    "name": "syft:package:metadataType",
+                    "value": "go-module-buildinfo-entry"
+                },
+                {
+                    "name": "syft:location:0:path",
+                    "value": "bomctl"
+                },
+                {
+                    "name": "syft:metadata:architecture",
+                    "value": "amd64"
+                },
+                {
+                    "name": "syft:metadata:goCompiledVersion",
+                    "value": "go1.22.2"
+                },
+                {
+                    "name": "syft:metadata:h1Digest",
+                    "value": "h1:rGGH0XDZhdUOryiDWjmIvUSWpbNqisK8Wk0Vyefw8hc="
+                },
+                {
+                    "name": "syft:metadata:mainModule",
+                    "value": "github.com/bomctl/bomctl"
+                }
+            ]
+        },
+        {
+            "bom-ref": "pkg:golang/github.com/subosito/gotenv@v1.4.2?package-id=b3cb5f58fa2babb1",
+            "type": "library",
+            "name": "github.com/subosito/gotenv",
+            "version": "v1.4.2",
+            "cpe": "cpe:2.3:a:subosito:gotenv:v1.4.2:*:*:*:*:*:*:*",
+            "purl": "pkg:golang/github.com/subosito/gotenv@v1.4.2",
+            "properties": [
+                {
+                    "name": "syft:package:foundBy",
+                    "value": "go-module-binary-cataloger"
+                },
+                {
+                    "name": "syft:package:language",
+                    "value": "go"
+                },
+                {
+                    "name": "syft:package:type",
+                    "value": "go-module"
+                },
+                {
+                    "name": "syft:package:metadataType",
+                    "value": "go-module-buildinfo-entry"
+                },
+                {
+                    "name": "syft:location:0:path",
+                    "value": "bomctl"
+                },
+                {
+                    "name": "syft:metadata:architecture",
+                    "value": "amd64"
+                },
+                {
+                    "name": "syft:metadata:goCompiledVersion",
+                    "value": "go1.22.2"
+                },
+                {
+                    "name": "syft:metadata:h1Digest",
+                    "value": "h1:X1TuBLAMDFbaTAChgCBLu3DU3UPyELpnF2jjJ2cz/S8="
+                },
+                {
+                    "name": "syft:metadata:mainModule",
+                    "value": "github.com/bomctl/bomctl"
+                }
+            ]
+        },
+        {
+            "bom-ref": "pkg:golang/github.com/xanzy/ssh-agent@v0.3.3?package-id=9dbfac8761face11",
+            "type": "library",
+            "name": "github.com/xanzy/ssh-agent",
+            "version": "v0.3.3",
+            "cpe": "cpe:2.3:a:xanzy:ssh-agent:v0.3.3:*:*:*:*:*:*:*",
+            "purl": "pkg:golang/github.com/xanzy/ssh-agent@v0.3.3",
+            "properties": [
+                {
+                    "name": "syft:package:foundBy",
+                    "value": "go-module-binary-cataloger"
+                },
+                {
+                    "name": "syft:package:language",
+                    "value": "go"
+                },
+                {
+                    "name": "syft:package:type",
+                    "value": "go-module"
+                },
+                {
+                    "name": "syft:package:metadataType",
+                    "value": "go-module-buildinfo-entry"
+                },
+                {
+                    "name": "syft:cpe23",
+                    "value": "cpe:2.3:a:xanzy:ssh_agent:v0.3.3:*:*:*:*:*:*:*"
+                },
+                {
+                    "name": "syft:location:0:path",
+                    "value": "bomctl"
+                },
+                {
+                    "name": "syft:metadata:architecture",
+                    "value": "amd64"
+                },
+                {
+                    "name": "syft:metadata:goCompiledVersion",
+                    "value": "go1.22.2"
+                },
+                {
+                    "name": "syft:metadata:h1Digest",
+                    "value": "h1:+/15pJfg/RsTxqYcX6fHqOXZwwMP+2VyYWJeWM2qQFM="
+                },
+                {
+                    "name": "syft:metadata:mainModule",
+                    "value": "github.com/bomctl/bomctl"
+                }
+            ]
+        },
+        {
+            "bom-ref": "pkg:golang/golang.org/x/crypto@v0.21.0?package-id=c7d8f17739574bcf",
+            "type": "library",
+            "name": "golang.org/x/crypto",
+            "version": "v0.21.0",
+            "cpe": "cpe:2.3:a:golang:x\\/crypto:v0.21.0:*:*:*:*:*:*:*",
+            "purl": "pkg:golang/golang.org/x/crypto@v0.21.0",
+            "properties": [
+                {
+                    "name": "syft:package:foundBy",
+                    "value": "go-module-binary-cataloger"
+                },
+                {
+                    "name": "syft:package:language",
+                    "value": "go"
+                },
+                {
+                    "name": "syft:package:type",
+                    "value": "go-module"
+                },
+                {
+                    "name": "syft:package:metadataType",
+                    "value": "go-module-buildinfo-entry"
+                },
+                {
+                    "name": "syft:location:0:path",
+                    "value": "bomctl"
+                },
+                {
+                    "name": "syft:metadata:architecture",
+                    "value": "amd64"
+                },
+                {
+                    "name": "syft:metadata:goCompiledVersion",
+                    "value": "go1.22.2"
+                },
+                {
+                    "name": "syft:metadata:h1Digest",
+                    "value": "h1:X31++rzVUdKhX5sWmSOFZxx8UW/ldWx55cbf08iNAMA="
+                },
+                {
+                    "name": "syft:metadata:mainModule",
+                    "value": "github.com/bomctl/bomctl"
+                }
+            ]
+        },
+        {
+            "bom-ref": "pkg:golang/golang.org/x/net@v0.23.0?package-id=d477fb3e31159b96",
+            "type": "library",
+            "name": "golang.org/x/net",
+            "version": "v0.23.0",
+            "cpe": "cpe:2.3:a:golang:x\\/net:v0.23.0:*:*:*:*:*:*:*",
+            "purl": "pkg:golang/golang.org/x/net@v0.23.0",
+            "properties": [
+                {
+                    "name": "syft:package:foundBy",
+                    "value": "go-module-binary-cataloger"
+                },
+                {
+                    "name": "syft:package:language",
+                    "value": "go"
+                },
+                {
+                    "name": "syft:package:type",
+                    "value": "go-module"
+                },
+                {
+                    "name": "syft:package:metadataType",
+                    "value": "go-module-buildinfo-entry"
+                },
+                {
+                    "name": "syft:location:0:path",
+                    "value": "bomctl"
+                },
+                {
+                    "name": "syft:metadata:architecture",
+                    "value": "amd64"
+                },
+                {
+                    "name": "syft:metadata:goCompiledVersion",
+                    "value": "go1.22.2"
+                },
+                {
+                    "name": "syft:metadata:h1Digest",
+                    "value": "h1:7EYJ93RZ9vYSZAIb2x3lnuvqO5zneoD6IvWjuhfxjTs="
+                },
+                {
+                    "name": "syft:metadata:mainModule",
+                    "value": "github.com/bomctl/bomctl"
+                }
+            ]
+        },
+        {
+            "bom-ref": "pkg:golang/golang.org/x/sync@v0.6.0?package-id=a2bd39baab98e866",
+            "type": "library",
+            "name": "golang.org/x/sync",
+            "version": "v0.6.0",
+            "cpe": "cpe:2.3:a:golang:x\\/sync:v0.6.0:*:*:*:*:*:*:*",
+            "purl": "pkg:golang/golang.org/x/sync@v0.6.0",
+            "properties": [
+                {
+                    "name": "syft:package:foundBy",
+                    "value": "go-module-binary-cataloger"
+                },
+                {
+                    "name": "syft:package:language",
+                    "value": "go"
+                },
+                {
+                    "name": "syft:package:type",
+                    "value": "go-module"
+                },
+                {
+                    "name": "syft:package:metadataType",
+                    "value": "go-module-buildinfo-entry"
+                },
+                {
+                    "name": "syft:location:0:path",
+                    "value": "bomctl"
+                },
+                {
+                    "name": "syft:metadata:architecture",
+                    "value": "amd64"
+                },
+                {
+                    "name": "syft:metadata:goCompiledVersion",
+                    "value": "go1.22.2"
+                },
+                {
+                    "name": "syft:metadata:h1Digest",
+                    "value": "h1:5BMeUDZ7vkXGfEr1x9B4bRcTH4lpkTkpdh0T/J+qjbQ="
+                },
+                {
+                    "name": "syft:metadata:mainModule",
+                    "value": "github.com/bomctl/bomctl"
+                }
+            ]
+        },
+        {
+            "bom-ref": "pkg:golang/golang.org/x/sys@v0.18.0?package-id=403c762d406fd790",
+            "type": "library",
+            "name": "golang.org/x/sys",
+            "version": "v0.18.0",
+            "cpe": "cpe:2.3:a:golang:x\\/sys:v0.18.0:*:*:*:*:*:*:*",
+            "purl": "pkg:golang/golang.org/x/sys@v0.18.0",
+            "properties": [
+                {
+                    "name": "syft:package:foundBy",
+                    "value": "go-module-binary-cataloger"
+                },
+                {
+                    "name": "syft:package:language",
+                    "value": "go"
+                },
+                {
+                    "name": "syft:package:type",
+                    "value": "go-module"
+                },
+                {
+                    "name": "syft:package:metadataType",
+                    "value": "go-module-buildinfo-entry"
+                },
+                {
+                    "name": "syft:location:0:path",
+                    "value": "bomctl"
+                },
+                {
+                    "name": "syft:metadata:architecture",
+                    "value": "amd64"
+                },
+                {
+                    "name": "syft:metadata:goCompiledVersion",
+                    "value": "go1.22.2"
+                },
+                {
+                    "name": "syft:metadata:h1Digest",
+                    "value": "h1:DBdB3niSjOA/O0blCZBqDefyWNYveAYMNF1Wum0DYQ4="
+                },
+                {
+                    "name": "syft:metadata:mainModule",
+                    "value": "github.com/bomctl/bomctl"
+                }
+            ]
+        },
+        {
+            "bom-ref": "pkg:golang/golang.org/x/text@v0.14.0?package-id=11c99eaecdce2ffd",
+            "type": "library",
+            "name": "golang.org/x/text",
+            "version": "v0.14.0",
+            "cpe": "cpe:2.3:a:golang:x\\/text:v0.14.0:*:*:*:*:*:*:*",
+            "purl": "pkg:golang/golang.org/x/text@v0.14.0",
+            "properties": [
+                {
+                    "name": "syft:package:foundBy",
+                    "value": "go-module-binary-cataloger"
+                },
+                {
+                    "name": "syft:package:language",
+                    "value": "go"
+                },
+                {
+                    "name": "syft:package:type",
+                    "value": "go-module"
+                },
+                {
+                    "name": "syft:package:metadataType",
+                    "value": "go-module-buildinfo-entry"
+                },
+                {
+                    "name": "syft:location:0:path",
+                    "value": "bomctl"
+                },
+                {
+                    "name": "syft:metadata:architecture",
+                    "value": "amd64"
+                },
+                {
+                    "name": "syft:metadata:goCompiledVersion",
+                    "value": "go1.22.2"
+                },
+                {
+                    "name": "syft:metadata:h1Digest",
+                    "value": "h1:ScX5w1eTa3QqT8oi6+ziP7dTV1S2+ALU0bI+0zXKWiQ="
+                },
+                {
+                    "name": "syft:metadata:mainModule",
+                    "value": "github.com/bomctl/bomctl"
+                }
+            ]
+        },
+        {
+            "bom-ref": "pkg:golang/google.golang.org/genproto@v0.0.0-20240125205218-1f4bbc51befe?package-id=906051058d2a6dd0",
+            "type": "library",
+            "name": "google.golang.org/genproto",
+            "version": "v0.0.0-20240125205218-1f4bbc51befe",
+            "cpe": "cpe:2.3:a:google:genproto:v0.0.0-20240125205218-1f4bbc51befe:*:*:*:*:*:*:*",
+            "purl": "pkg:golang/google.golang.org/genproto@v0.0.0-20240125205218-1f4bbc51befe",
+            "properties": [
+                {
+                    "name": "syft:package:foundBy",
+                    "value": "go-module-binary-cataloger"
+                },
+                {
+                    "name": "syft:package:language",
+                    "value": "go"
+                },
+                {
+                    "name": "syft:package:type",
+                    "value": "go-module"
+                },
+                {
+                    "name": "syft:package:metadataType",
+                    "value": "go-module-buildinfo-entry"
+                },
+                {
+                    "name": "syft:location:0:path",
+                    "value": "bomctl"
+                },
+                {
+                    "name": "syft:metadata:architecture",
+                    "value": "amd64"
+                },
+                {
+                    "name": "syft:metadata:goCompiledVersion",
+                    "value": "go1.22.2"
+                },
+                {
+                    "name": "syft:metadata:h1Digest",
+                    "value": "h1:USL2DhxfgRchafRvt/wYyyQNzwgL7ZiURcozOE/Pkvo="
+                },
+                {
+                    "name": "syft:metadata:mainModule",
+                    "value": "github.com/bomctl/bomctl"
+                }
+            ]
+        },
+        {
+            "bom-ref": "pkg:golang/google.golang.org/genproto/googleapis@v0.0.0-20240125205218-1f4bbc51befe?package-id=02440c70fac6bf28#rpc",
+            "type": "library",
+            "name": "google.golang.org/genproto/googleapis/rpc",
+            "version": "v0.0.0-20240125205218-1f4bbc51befe",
+            "cpe": "cpe:2.3:a:google:genproto:v0.0.0-20240125205218-1f4bbc51befe:*:*:*:*:*:*:*",
+            "purl": "pkg:golang/google.golang.org/genproto/googleapis@v0.0.0-20240125205218-1f4bbc51befe#rpc",
+            "properties": [
+                {
+                    "name": "syft:package:foundBy",
+                    "value": "go-module-binary-cataloger"
+                },
+                {
+                    "name": "syft:package:language",
+                    "value": "go"
+                },
+                {
+                    "name": "syft:package:type",
+                    "value": "go-module"
+                },
+                {
+                    "name": "syft:package:metadataType",
+                    "value": "go-module-buildinfo-entry"
+                },
+                {
+                    "name": "syft:location:0:path",
+                    "value": "bomctl"
+                },
+                {
+                    "name": "syft:metadata:architecture",
+                    "value": "amd64"
+                },
+                {
+                    "name": "syft:metadata:goCompiledVersion",
+                    "value": "go1.22.2"
+                },
+                {
+                    "name": "syft:metadata:h1Digest",
+                    "value": "h1:bQnxqljG/wqi4NTXu2+DJ3n7APcEA882QZ1JvhQAq9o="
+                },
+                {
+                    "name": "syft:metadata:mainModule",
+                    "value": "github.com/bomctl/bomctl"
+                }
+            ]
+        },
+        {
+            "bom-ref": "pkg:golang/google.golang.org/grpc@v1.61.0?package-id=feba26324ca36068",
+            "type": "library",
+            "name": "google.golang.org/grpc",
+            "version": "v1.61.0",
+            "cpe": "cpe:2.3:a:google:grpc:v1.61.0:*:*:*:*:*:*:*",
+            "purl": "pkg:golang/google.golang.org/grpc@v1.61.0",
+            "properties": [
+                {
+                    "name": "syft:package:foundBy",
+                    "value": "go-module-binary-cataloger"
+                },
+                {
+                    "name": "syft:package:language",
+                    "value": "go"
+                },
+                {
+                    "name": "syft:package:type",
+                    "value": "go-module"
+                },
+                {
+                    "name": "syft:package:metadataType",
+                    "value": "go-module-buildinfo-entry"
+                },
+                {
+                    "name": "syft:location:0:path",
+                    "value": "bomctl"
+                },
+                {
+                    "name": "syft:metadata:architecture",
+                    "value": "amd64"
+                },
+                {
+                    "name": "syft:metadata:goCompiledVersion",
+                    "value": "go1.22.2"
+                },
+                {
+                    "name": "syft:metadata:h1Digest",
+                    "value": "h1:TOvOcuXn30kRao+gfcvsebNEa5iZIiLkisYEkf7R7o0="
+                },
+                {
+                    "name": "syft:metadata:mainModule",
+                    "value": "github.com/bomctl/bomctl"
+                }
+            ]
+        },
+        {
+            "bom-ref": "pkg:golang/google.golang.org/protobuf@v1.33.0?package-id=c9a81b13009cd3ac",
+            "type": "library",
+            "name": "google.golang.org/protobuf",
+            "version": "v1.33.0",
+            "cpe": "cpe:2.3:a:google:protobuf:v1.33.0:*:*:*:*:*:*:*",
+            "purl": "pkg:golang/google.golang.org/protobuf@v1.33.0",
+            "properties": [
+                {
+                    "name": "syft:package:foundBy",
+                    "value": "go-module-binary-cataloger"
+                },
+                {
+                    "name": "syft:package:language",
+                    "value": "go"
+                },
+                {
+                    "name": "syft:package:type",
+                    "value": "go-module"
+                },
+                {
+                    "name": "syft:package:metadataType",
+                    "value": "go-module-buildinfo-entry"
+                },
+                {
+                    "name": "syft:location:0:path",
+                    "value": "bomctl"
+                },
+                {
+                    "name": "syft:metadata:architecture",
+                    "value": "amd64"
+                },
+                {
+                    "name": "syft:metadata:goCompiledVersion",
+                    "value": "go1.22.2"
+                },
+                {
+                    "name": "syft:metadata:h1Digest",
+                    "value": "h1:uNO2rsAINq/JlFpSdYEKIZ0uKD/R9cpdv0T+yoGwGmI="
+                },
+                {
+                    "name": "syft:metadata:mainModule",
+                    "value": "github.com/bomctl/bomctl"
+                }
+            ]
+        },
+        {
+            "bom-ref": "pkg:golang/gopkg.in/ini.v1@v1.67.0?package-id=b9ef91c06d804e82",
+            "type": "library",
+            "name": "gopkg.in/ini.v1",
+            "version": "v1.67.0",
+            "purl": "pkg:golang/gopkg.in/ini.v1@v1.67.0",
+            "properties": [
+                {
+                    "name": "syft:package:foundBy",
+                    "value": "go-module-binary-cataloger"
+                },
+                {
+                    "name": "syft:package:language",
+                    "value": "go"
+                },
+                {
+                    "name": "syft:package:type",
+                    "value": "go-module"
+                },
+                {
+                    "name": "syft:package:metadataType",
+                    "value": "go-module-buildinfo-entry"
+                },
+                {
+                    "name": "syft:location:0:path",
+                    "value": "bomctl"
+                },
+                {
+                    "name": "syft:metadata:architecture",
+                    "value": "amd64"
+                },
+                {
+                    "name": "syft:metadata:goCompiledVersion",
+                    "value": "go1.22.2"
+                },
+                {
+                    "name": "syft:metadata:h1Digest",
+                    "value": "h1:Dgnx+6+nfE+IfzjUEISNeydPJh9AXNNsWbGP9KzCsOA="
+                },
+                {
+                    "name": "syft:metadata:mainModule",
+                    "value": "github.com/bomctl/bomctl"
+                }
+            ]
+        },
+        {
+            "bom-ref": "pkg:golang/gopkg.in/warnings.v0@v0.1.2?package-id=5395fdc190431205",
+            "type": "library",
+            "name": "gopkg.in/warnings.v0",
+            "version": "v0.1.2",
+            "purl": "pkg:golang/gopkg.in/warnings.v0@v0.1.2",
+            "properties": [
+                {
+                    "name": "syft:package:foundBy",
+                    "value": "go-module-binary-cataloger"
+                },
+                {
+                    "name": "syft:package:language",
+                    "value": "go"
+                },
+                {
+                    "name": "syft:package:type",
+                    "value": "go-module"
+                },
+                {
+                    "name": "syft:package:metadataType",
+                    "value": "go-module-buildinfo-entry"
+                },
+                {
+                    "name": "syft:location:0:path",
+                    "value": "bomctl"
+                },
+                {
+                    "name": "syft:metadata:architecture",
+                    "value": "amd64"
+                },
+                {
+                    "name": "syft:metadata:goCompiledVersion",
+                    "value": "go1.22.2"
+                },
+                {
+                    "name": "syft:metadata:h1Digest",
+                    "value": "h1:wFXVbFY8DY5/xOe1ECiWdKCzZlxgshcYVNkBHstARME="
+                },
+                {
+                    "name": "syft:metadata:mainModule",
+                    "value": "github.com/bomctl/bomctl"
+                }
+            ]
+        },
+        {
+            "bom-ref": "pkg:golang/gopkg.in/yaml.v3@v3.0.1?package-id=70c0ba9aad25fe36",
+            "type": "library",
+            "name": "gopkg.in/yaml.v3",
+            "version": "v3.0.1",
+            "purl": "pkg:golang/gopkg.in/yaml.v3@v3.0.1",
+            "properties": [
+                {
+                    "name": "syft:package:foundBy",
+                    "value": "go-module-binary-cataloger"
+                },
+                {
+                    "name": "syft:package:language",
+                    "value": "go"
+                },
+                {
+                    "name": "syft:package:type",
+                    "value": "go-module"
+                },
+                {
+                    "name": "syft:package:metadataType",
+                    "value": "go-module-buildinfo-entry"
+                },
+                {
+                    "name": "syft:location:0:path",
+                    "value": "bomctl"
+                },
+                {
+                    "name": "syft:metadata:architecture",
+                    "value": "amd64"
+                },
+                {
+                    "name": "syft:metadata:goCompiledVersion",
+                    "value": "go1.22.2"
+                },
+                {
+                    "name": "syft:metadata:h1Digest",
+                    "value": "h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA="
+                },
+                {
+                    "name": "syft:metadata:mainModule",
+                    "value": "github.com/bomctl/bomctl"
+                }
+            ]
+        },
+        {
+            "bom-ref": "pkg:golang/gorm.io/gorm@v1.25.6?package-id=2db629d21f30120f",
+            "type": "library",
+            "name": "gorm.io/gorm",
+            "version": "v1.25.6",
+            "purl": "pkg:golang/gorm.io/gorm@v1.25.6",
+            "properties": [
+                {
+                    "name": "syft:package:foundBy",
+                    "value": "go-module-binary-cataloger"
+                },
+                {
+                    "name": "syft:package:language",
+                    "value": "go"
+                },
+                {
+                    "name": "syft:package:type",
+                    "value": "go-module"
+                },
+                {
+                    "name": "syft:package:metadataType",
+                    "value": "go-module-buildinfo-entry"
+                },
+                {
+                    "name": "syft:location:0:path",
+                    "value": "bomctl"
+                },
+                {
+                    "name": "syft:metadata:architecture",
+                    "value": "amd64"
+                },
+                {
+                    "name": "syft:metadata:goCompiledVersion",
+                    "value": "go1.22.2"
+                },
+                {
+                    "name": "syft:metadata:h1Digest",
+                    "value": "h1:V92+vVda1wEISSOMtodHVRcUIOPYa2tgQtyF+DfFx+A="
+                },
+                {
+                    "name": "syft:metadata:mainModule",
+                    "value": "github.com/bomctl/bomctl"
+                }
+            ]
+        },
+        {
+            "bom-ref": "pkg:golang/modernc.org/libc@v1.40.6?package-id=37a1bd90cb4114b7",
+            "type": "library",
+            "name": "modernc.org/libc",
+            "version": "v1.40.6",
+            "purl": "pkg:golang/modernc.org/libc@v1.40.6",
+            "properties": [
+                {
+                    "name": "syft:package:foundBy",
+                    "value": "go-module-binary-cataloger"
+                },
+                {
+                    "name": "syft:package:language",
+                    "value": "go"
+                },
+                {
+                    "name": "syft:package:type",
+                    "value": "go-module"
+                },
+                {
+                    "name": "syft:package:metadataType",
+                    "value": "go-module-buildinfo-entry"
+                },
+                {
+                    "name": "syft:location:0:path",
+                    "value": "bomctl"
+                },
+                {
+                    "name": "syft:metadata:architecture",
+                    "value": "amd64"
+                },
+                {
+                    "name": "syft:metadata:goCompiledVersion",
+                    "value": "go1.22.2"
+                },
+                {
+                    "name": "syft:metadata:h1Digest",
+                    "value": "h1:141JHq3SjhOOCjECBgD4K8VgTFOy19CnHwroC08DAig="
+                },
+                {
+                    "name": "syft:metadata:mainModule",
+                    "value": "github.com/bomctl/bomctl"
+                }
+            ]
+        },
+        {
+            "bom-ref": "pkg:golang/modernc.org/mathutil@v1.6.0?package-id=aecbf01e9524c98e",
+            "type": "library",
+            "name": "modernc.org/mathutil",
+            "version": "v1.6.0",
+            "purl": "pkg:golang/modernc.org/mathutil@v1.6.0",
+            "properties": [
+                {
+                    "name": "syft:package:foundBy",
+                    "value": "go-module-binary-cataloger"
+                },
+                {
+                    "name": "syft:package:language",
+                    "value": "go"
+                },
+                {
+                    "name": "syft:package:type",
+                    "value": "go-module"
+                },
+                {
+                    "name": "syft:package:metadataType",
+                    "value": "go-module-buildinfo-entry"
+                },
+                {
+                    "name": "syft:location:0:path",
+                    "value": "bomctl"
+                },
+                {
+                    "name": "syft:metadata:architecture",
+                    "value": "amd64"
+                },
+                {
+                    "name": "syft:metadata:goCompiledVersion",
+                    "value": "go1.22.2"
+                },
+                {
+                    "name": "syft:metadata:h1Digest",
+                    "value": "h1:fRe9+AmYlaej+64JsEEhoWuAYBkOtQiMEU7n/XgfYi4="
+                },
+                {
+                    "name": "syft:metadata:mainModule",
+                    "value": "github.com/bomctl/bomctl"
+                }
+            ]
+        },
+        {
+            "bom-ref": "pkg:golang/modernc.org/memory@v1.7.2?package-id=db9eb5442b16bbdb",
+            "type": "library",
+            "name": "modernc.org/memory",
+            "version": "v1.7.2",
+            "purl": "pkg:golang/modernc.org/memory@v1.7.2",
+            "properties": [
+                {
+                    "name": "syft:package:foundBy",
+                    "value": "go-module-binary-cataloger"
+                },
+                {
+                    "name": "syft:package:language",
+                    "value": "go"
+                },
+                {
+                    "name": "syft:package:type",
+                    "value": "go-module"
+                },
+                {
+                    "name": "syft:package:metadataType",
+                    "value": "go-module-buildinfo-entry"
+                },
+                {
+                    "name": "syft:location:0:path",
+                    "value": "bomctl"
+                },
+                {
+                    "name": "syft:metadata:architecture",
+                    "value": "amd64"
+                },
+                {
+                    "name": "syft:metadata:goCompiledVersion",
+                    "value": "go1.22.2"
+                },
+                {
+                    "name": "syft:metadata:h1Digest",
+                    "value": "h1:Klh90S215mmH8c9gO98QxQFsY+W451E8AnzjoE2ee1E="
+                },
+                {
+                    "name": "syft:metadata:mainModule",
+                    "value": "github.com/bomctl/bomctl"
+                }
+            ]
+        },
+        {
+            "bom-ref": "pkg:golang/modernc.org/sqlite@v1.28.0?package-id=583859c2c1497ad0",
+            "type": "library",
+            "name": "modernc.org/sqlite",
+            "version": "v1.28.0",
+            "purl": "pkg:golang/modernc.org/sqlite@v1.28.0",
+            "properties": [
+                {
+                    "name": "syft:package:foundBy",
+                    "value": "go-module-binary-cataloger"
+                },
+                {
+                    "name": "syft:package:language",
+                    "value": "go"
+                },
+                {
+                    "name": "syft:package:type",
+                    "value": "go-module"
+                },
+                {
+                    "name": "syft:package:metadataType",
+                    "value": "go-module-buildinfo-entry"
+                },
+                {
+                    "name": "syft:location:0:path",
+                    "value": "bomctl"
+                },
+                {
+                    "name": "syft:metadata:architecture",
+                    "value": "amd64"
+                },
+                {
+                    "name": "syft:metadata:goCompiledVersion",
+                    "value": "go1.22.2"
+                },
+                {
+                    "name": "syft:metadata:h1Digest",
+                    "value": "h1:Zx+LyDDmXczNnEQdvPuEfcFVA2ZPyaD7UCZDjef3BHQ="
+                },
+                {
+                    "name": "syft:metadata:mainModule",
+                    "value": "github.com/bomctl/bomctl"
+                }
+            ]
+        },
+        {
+            "bom-ref": "pkg:golang/oras.land/oras-go/v2@v2.4.0?package-id=057786d9e849f152",
+            "type": "library",
+            "name": "oras.land/oras-go/v2",
+            "version": "v2.4.0",
+            "cpe": "cpe:2.3:a:oras-go:v2:v2.4.0:*:*:*:*:*:*:*",
+            "purl": "pkg:golang/oras.land/oras-go/v2@v2.4.0",
+            "properties": [
+                {
+                    "name": "syft:package:foundBy",
+                    "value": "go-module-binary-cataloger"
+                },
+                {
+                    "name": "syft:package:language",
+                    "value": "go"
+                },
+                {
+                    "name": "syft:package:type",
+                    "value": "go-module"
+                },
+                {
+                    "name": "syft:package:metadataType",
+                    "value": "go-module-buildinfo-entry"
+                },
+                {
+                    "name": "syft:cpe23",
+                    "value": "cpe:2.3:a:oras_go:v2:v2.4.0:*:*:*:*:*:*:*"
+                },
+                {
+                    "name": "syft:cpe23",
+                    "value": "cpe:2.3:a:oras:v2:v2.4.0:*:*:*:*:*:*:*"
+                },
+                {
+                    "name": "syft:location:0:path",
+                    "value": "bomctl"
+                },
+                {
+                    "name": "syft:metadata:architecture",
+                    "value": "amd64"
+                },
+                {
+                    "name": "syft:metadata:goCompiledVersion",
+                    "value": "go1.22.2"
+                },
+                {
+                    "name": "syft:metadata:h1Digest",
+                    "value": "h1:i+Wt5oCaMHu99guBD0yuBjdLvX7Lz8ukPbwXdR7uBMs="
+                },
+                {
+                    "name": "syft:metadata:mainModule",
+                    "value": "github.com/bomctl/bomctl"
+                }
+            ]
+        },
+        {
+            "bom-ref": "pkg:golang/stdlib@1.22.2?package-id=10a76d4043c697eb",
+            "type": "library",
+            "name": "stdlib",
+            "version": "go1.22.2",
+            "licenses": [
+                {
+                    "license": {
+                        "id": "BSD-3-Clause"
+                    }
+                }
+            ],
+            "cpe": "cpe:2.3:a:golang:go:1.22.2:-:*:*:*:*:*:*",
+            "purl": "pkg:golang/stdlib@1.22.2",
+            "properties": [
+                {
+                    "name": "syft:package:language",
+                    "value": "go"
+                },
+                {
+                    "name": "syft:package:type",
+                    "value": "go-module"
+                },
+                {
+                    "name": "syft:package:metadataType",
+                    "value": "go-module-buildinfo-entry"
+                },
+                {
+                    "name": "syft:location:0:path",
+                    "value": "bomctl"
+                },
+                {
+                    "name": "syft:metadata:goCompiledVersion",
+                    "value": "go1.22.2"
+                }
+            ]
+        }
+    ]
+}

--- a/examples/bomctl_0.3.0_darwin_arm64.tar.gz.spdx.json
+++ b/examples/bomctl_0.3.0_darwin_arm64.tar.gz.spdx.json
@@ -1,0 +1,3897 @@
+{
+    "spdxVersion": "SPDX-2.3",
+    "dataLicense": "CC0-1.0",
+    "SPDXID": "SPDXRef-DOCUMENT",
+    "name": "bomctl_0.3.0_darwin_arm64.tar.gz",
+    "documentNamespace": "https://anchore.com/syft/file/bomctl_0.3.0_darwin_arm64.tar.gz-09607ff6-8dbf-4f20-b1c0-7b29e8cdcf94",
+    "creationInfo": {
+      "licenseListVersion": "3.24",
+      "creators": [
+        "Organization: Anchore, Inc",
+        "Tool: syft-1.9.0"
+      ],
+      "created": "2024-08-07T21:17:55Z"
+    },
+    "packages": [
+      {
+        "name": "ariga.io/atlas",
+        "SPDXID": "SPDXRef-Package-go-module-ariga.io-atlas-c7e8a33efe528bcd",
+        "versionInfo": "v0.19.1-0.20240203083654-5948b60a8e43",
+        "supplier": "NOASSERTION",
+        "downloadLocation": "NOASSERTION",
+        "filesAnalyzed": false,
+        "checksums": [
+          {
+            "algorithm": "SHA256",
+            "checksumValue": "1b07496d7c9d1c260f79d79e2ede31fe5ae5208490e094c7d66456b84e59675e"
+          }
+        ],
+        "sourceInfo": "acquired package info from go module information: bomctl",
+        "licenseConcluded": "NOASSERTION",
+        "licenseDeclared": "NOASSERTION",
+        "copyrightText": "NOASSERTION",
+        "externalRefs": [
+          {
+            "referenceCategory": "PACKAGE-MANAGER",
+            "referenceType": "purl",
+            "referenceLocator": "pkg:golang/ariga.io/atlas@v0.19.1-0.20240203083654-5948b60a8e43"
+          }
+        ]
+      },
+      {
+        "name": "dario.cat/mergo",
+        "SPDXID": "SPDXRef-Package-go-module-dario.cat-mergo-d5fcd2c2377a1cd1",
+        "versionInfo": "v1.0.0",
+        "supplier": "NOASSERTION",
+        "downloadLocation": "NOASSERTION",
+        "filesAnalyzed": false,
+        "checksums": [
+          {
+            "algorithm": "SHA256",
+            "checksumValue": "00608dabd12fb23df598e80d3dc2f25dcfb83cd001b7dd39626baa3d86290569"
+          }
+        ],
+        "sourceInfo": "acquired package info from go module information: bomctl",
+        "licenseConcluded": "NOASSERTION",
+        "licenseDeclared": "NOASSERTION",
+        "copyrightText": "NOASSERTION",
+        "externalRefs": [
+          {
+            "referenceCategory": "PACKAGE-MANAGER",
+            "referenceType": "purl",
+            "referenceLocator": "pkg:golang/dario.cat/mergo@v1.0.0"
+          }
+        ]
+      },
+      {
+        "name": "entgo.io/ent",
+        "SPDXID": "SPDXRef-Package-go-module-entgo.io-ent-2f326bd8f7351e93",
+        "versionInfo": "v0.13.1",
+        "supplier": "NOASSERTION",
+        "downloadLocation": "NOASSERTION",
+        "filesAnalyzed": false,
+        "checksums": [
+          {
+            "algorithm": "SHA256",
+            "checksumValue": "b83f10c0dd61e9236985d082ce690c3777de494ccd9d5bd5fd62241ca31bcce1"
+          }
+        ],
+        "sourceInfo": "acquired package info from go module information: bomctl",
+        "licenseConcluded": "NOASSERTION",
+        "licenseDeclared": "NOASSERTION",
+        "copyrightText": "NOASSERTION",
+        "externalRefs": [
+          {
+            "referenceCategory": "PACKAGE-MANAGER",
+            "referenceType": "purl",
+            "referenceLocator": "pkg:golang/entgo.io/ent@v0.13.1"
+          }
+        ]
+      },
+      {
+        "name": "github.com/CycloneDX/cyclonedx-go",
+        "SPDXID": "SPDXRef-Package-go-module-github.com-CycloneDX-cyclonedx-go-123d16cf974edfaa",
+        "versionInfo": "v0.9.0",
+        "supplier": "NOASSERTION",
+        "downloadLocation": "NOASSERTION",
+        "filesAnalyzed": false,
+        "checksums": [
+          {
+            "algorithm": "SHA256",
+            "checksumValue": "8a76a27fba83f1b8afcb1a7b5cb831518b4e5d6b437b3efe8fbdaa2933104dbf"
+          }
+        ],
+        "sourceInfo": "acquired package info from go module information: bomctl",
+        "licenseConcluded": "NOASSERTION",
+        "licenseDeclared": "NOASSERTION",
+        "copyrightText": "NOASSERTION",
+        "externalRefs": [
+          {
+            "referenceCategory": "SECURITY",
+            "referenceType": "cpe23Type",
+            "referenceLocator": "cpe:2.3:a:CycloneDX:cyclonedx-go:v0.9.0:*:*:*:*:*:*:*"
+          },
+          {
+            "referenceCategory": "SECURITY",
+            "referenceType": "cpe23Type",
+            "referenceLocator": "cpe:2.3:a:CycloneDX:cyclonedx_go:v0.9.0:*:*:*:*:*:*:*"
+          },
+          {
+            "referenceCategory": "PACKAGE-MANAGER",
+            "referenceType": "purl",
+            "referenceLocator": "pkg:golang/github.com/CycloneDX/cyclonedx-go@v0.9.0"
+          }
+        ]
+      },
+      {
+        "name": "github.com/ProtonMail/go-crypto",
+        "SPDXID": "SPDXRef-Package-go-module-github.com-ProtonMail-go-crypto-0ed0e0ef656bde63",
+        "versionInfo": "v1.0.0",
+        "supplier": "NOASSERTION",
+        "downloadLocation": "NOASSERTION",
+        "filesAnalyzed": false,
+        "checksums": [
+          {
+            "algorithm": "SHA256",
+            "checksumValue": "2d1baf2138d0597f9621fafddf46071b61cd7e3475b8e7f27f9bc4d240b653bf"
+          }
+        ],
+        "sourceInfo": "acquired package info from go module information: bomctl",
+        "licenseConcluded": "NOASSERTION",
+        "licenseDeclared": "NOASSERTION",
+        "copyrightText": "NOASSERTION",
+        "externalRefs": [
+          {
+            "referenceCategory": "SECURITY",
+            "referenceType": "cpe23Type",
+            "referenceLocator": "cpe:2.3:a:ProtonMail:go-crypto:v1.0.0:*:*:*:*:*:*:*"
+          },
+          {
+            "referenceCategory": "SECURITY",
+            "referenceType": "cpe23Type",
+            "referenceLocator": "cpe:2.3:a:ProtonMail:go_crypto:v1.0.0:*:*:*:*:*:*:*"
+          },
+          {
+            "referenceCategory": "PACKAGE-MANAGER",
+            "referenceType": "purl",
+            "referenceLocator": "pkg:golang/github.com/ProtonMail/go-crypto@v1.0.0"
+          }
+        ]
+      },
+      {
+        "name": "github.com/agext/levenshtein",
+        "SPDXID": "SPDXRef-Package-go-module-github.com-agext-levenshtein-55b76fe4d029a0ff",
+        "versionInfo": "v1.2.1",
+        "supplier": "NOASSERTION",
+        "downloadLocation": "NOASSERTION",
+        "filesAnalyzed": false,
+        "checksums": [
+          {
+            "algorithm": "SHA256",
+            "checksumValue": "426bcc0238f6684202cad1a25b39b1a04d31d8a66f1347ef9aa30e7f2dad8d3f"
+          }
+        ],
+        "sourceInfo": "acquired package info from go module information: bomctl",
+        "licenseConcluded": "NOASSERTION",
+        "licenseDeclared": "NOASSERTION",
+        "copyrightText": "NOASSERTION",
+        "externalRefs": [
+          {
+            "referenceCategory": "SECURITY",
+            "referenceType": "cpe23Type",
+            "referenceLocator": "cpe:2.3:a:agext:levenshtein:v1.2.1:*:*:*:*:*:*:*"
+          },
+          {
+            "referenceCategory": "PACKAGE-MANAGER",
+            "referenceType": "purl",
+            "referenceLocator": "pkg:golang/github.com/agext/levenshtein@v1.2.1"
+          }
+        ]
+      },
+      {
+        "name": "github.com/anchore/go-struct-converter",
+        "SPDXID": "SPDXRef-Package-go-module-github.com-anchore-go-struct-converter-540179a74d1ce890",
+        "versionInfo": "v0.0.0-20230627203149-c72ef8859ca9",
+        "supplier": "NOASSERTION",
+        "downloadLocation": "NOASSERTION",
+        "filesAnalyzed": false,
+        "checksums": [
+          {
+            "algorithm": "SHA256",
+            "checksumValue": "e823a95d6a476e158cd7081c40df794ddb26acb4db6bc2907cf8089815f39230"
+          }
+        ],
+        "sourceInfo": "acquired package info from go module information: bomctl",
+        "licenseConcluded": "NOASSERTION",
+        "licenseDeclared": "NOASSERTION",
+        "copyrightText": "NOASSERTION",
+        "externalRefs": [
+          {
+            "referenceCategory": "SECURITY",
+            "referenceType": "cpe23Type",
+            "referenceLocator": "cpe:2.3:a:anchore:go-struct-converter:v0.0.0-20230627203149-c72ef8859ca9:*:*:*:*:*:*:*"
+          },
+          {
+            "referenceCategory": "SECURITY",
+            "referenceType": "cpe23Type",
+            "referenceLocator": "cpe:2.3:a:anchore:go_struct_converter:v0.0.0-20230627203149-c72ef8859ca9:*:*:*:*:*:*:*"
+          },
+          {
+            "referenceCategory": "PACKAGE-MANAGER",
+            "referenceType": "purl",
+            "referenceLocator": "pkg:golang/github.com/anchore/go-struct-converter@v0.0.0-20230627203149-c72ef8859ca9"
+          }
+        ]
+      },
+      {
+        "name": "github.com/apparentlymart/go-textseg/v13",
+        "SPDXID": "SPDXRef-Package-go-module-github.com-apparentlymart-go-textseg-v13-1c79ce3d5e07ff7f",
+        "versionInfo": "v13.0.0",
+        "supplier": "NOASSERTION",
+        "downloadLocation": "NOASSERTION",
+        "filesAnalyzed": false,
+        "checksums": [
+          {
+            "algorithm": "SHA256",
+            "checksumValue": "63e2af3c4d4d633d3197ad353d52267907c5c84cba893f7402f3d42f534d7cdc"
+          }
+        ],
+        "sourceInfo": "acquired package info from go module information: bomctl",
+        "licenseConcluded": "NOASSERTION",
+        "licenseDeclared": "NOASSERTION",
+        "copyrightText": "NOASSERTION",
+        "externalRefs": [
+          {
+            "referenceCategory": "SECURITY",
+            "referenceType": "cpe23Type",
+            "referenceLocator": "cpe:2.3:a:apparentlymart:go-textseg\\/v13:v13.0.0:*:*:*:*:*:*:*"
+          },
+          {
+            "referenceCategory": "SECURITY",
+            "referenceType": "cpe23Type",
+            "referenceLocator": "cpe:2.3:a:apparentlymart:go_textseg\\/v13:v13.0.0:*:*:*:*:*:*:*"
+          },
+          {
+            "referenceCategory": "PACKAGE-MANAGER",
+            "referenceType": "purl",
+            "referenceLocator": "pkg:golang/github.com/apparentlymart/go-textseg@v13.0.0#v13"
+          }
+        ]
+      },
+      {
+        "name": "github.com/aymanbagabas/go-osc52/v2",
+        "SPDXID": "SPDXRef-Package-go-module-github.com-aymanbagabas-go-osc52-v2-fb00d93211f62e73",
+        "versionInfo": "v2.0.1",
+        "supplier": "NOASSERTION",
+        "downloadLocation": "NOASSERTION",
+        "filesAnalyzed": false,
+        "checksums": [
+          {
+            "algorithm": "SHA256",
+            "checksumValue": "1f0a511db14c7192c456be360f8a7b5c1aa3caec501f948c884ac34f85a42769"
+          }
+        ],
+        "sourceInfo": "acquired package info from go module information: bomctl",
+        "licenseConcluded": "NOASSERTION",
+        "licenseDeclared": "NOASSERTION",
+        "copyrightText": "NOASSERTION",
+        "externalRefs": [
+          {
+            "referenceCategory": "SECURITY",
+            "referenceType": "cpe23Type",
+            "referenceLocator": "cpe:2.3:a:aymanbagabas:go-osc52\\/v2:v2.0.1:*:*:*:*:*:*:*"
+          },
+          {
+            "referenceCategory": "SECURITY",
+            "referenceType": "cpe23Type",
+            "referenceLocator": "cpe:2.3:a:aymanbagabas:go_osc52\\/v2:v2.0.1:*:*:*:*:*:*:*"
+          },
+          {
+            "referenceCategory": "PACKAGE-MANAGER",
+            "referenceType": "purl",
+            "referenceLocator": "pkg:golang/github.com/aymanbagabas/go-osc52@v2.0.1#v2"
+          }
+        ]
+      },
+      {
+        "name": "github.com/blang/semver/v4",
+        "SPDXID": "SPDXRef-Package-go-module-github.com-blang-semver-v4-d63527ef931efe69",
+        "versionInfo": "v4.0.0",
+        "supplier": "NOASSERTION",
+        "downloadLocation": "NOASSERTION",
+        "filesAnalyzed": false,
+        "checksums": [
+          {
+            "algorithm": "SHA256",
+            "checksumValue": "d4f147144eb20824eff02d537b234d6ab0f39ed2e2ef0308e62fe9cea608b003"
+          }
+        ],
+        "sourceInfo": "acquired package info from go module information: bomctl",
+        "licenseConcluded": "NOASSERTION",
+        "licenseDeclared": "NOASSERTION",
+        "copyrightText": "NOASSERTION",
+        "externalRefs": [
+          {
+            "referenceCategory": "SECURITY",
+            "referenceType": "cpe23Type",
+            "referenceLocator": "cpe:2.3:a:blang:semver\\/v4:v4.0.0:*:*:*:*:*:*:*"
+          },
+          {
+            "referenceCategory": "PACKAGE-MANAGER",
+            "referenceType": "purl",
+            "referenceLocator": "pkg:golang/github.com/blang/semver@v4.0.0#v4"
+          }
+        ]
+      },
+      {
+        "name": "github.com/bomctl/bomctl",
+        "SPDXID": "SPDXRef-Package-go-module-github.com-bomctl-bomctl-d3de1d7b912744e1",
+        "versionInfo": "v0.3.0",
+        "supplier": "NOASSERTION",
+        "downloadLocation": "NOASSERTION",
+        "filesAnalyzed": false,
+        "checksums": [
+          {
+            "algorithm": "SHA256",
+            "checksumValue": "68984fb121ff3bb3e45c2891c9652859e5730a46e450cede6ed8da4c9ddb09ee"
+          }
+        ],
+        "sourceInfo": "acquired package info from go module information: bomctl",
+        "licenseConcluded": "NOASSERTION",
+        "licenseDeclared": "NOASSERTION",
+        "copyrightText": "NOASSERTION",
+        "externalRefs": [
+          {
+            "referenceCategory": "SECURITY",
+            "referenceType": "cpe23Type",
+            "referenceLocator": "cpe:2.3:a:bomctl:bomctl:v0.3.0:*:*:*:*:*:*:*"
+          },
+          {
+            "referenceCategory": "PACKAGE-MANAGER",
+            "referenceType": "purl",
+            "referenceLocator": "pkg:golang/github.com/bomctl/bomctl@v0.3.0"
+          }
+        ]
+      },
+      {
+        "name": "github.com/charmbracelet/lipgloss",
+        "SPDXID": "SPDXRef-Package-go-module-github.com-charmbracelet-lipgloss-3c246a3a04019348",
+        "versionInfo": "v0.12.1",
+        "supplier": "NOASSERTION",
+        "downloadLocation": "NOASSERTION",
+        "filesAnalyzed": false,
+        "checksums": [
+          {
+            "algorithm": "SHA256",
+            "checksumValue": "fe09b3b3397ea5e750a6308e1fec05919aff37dd129f3e3427f351ec0d3341cb"
+          }
+        ],
+        "sourceInfo": "acquired package info from go module information: bomctl",
+        "licenseConcluded": "NOASSERTION",
+        "licenseDeclared": "NOASSERTION",
+        "copyrightText": "NOASSERTION",
+        "externalRefs": [
+          {
+            "referenceCategory": "SECURITY",
+            "referenceType": "cpe23Type",
+            "referenceLocator": "cpe:2.3:a:charmbracelet:lipgloss:v0.12.1:*:*:*:*:*:*:*"
+          },
+          {
+            "referenceCategory": "PACKAGE-MANAGER",
+            "referenceType": "purl",
+            "referenceLocator": "pkg:golang/github.com/charmbracelet/lipgloss@v0.12.1"
+          }
+        ]
+      },
+      {
+        "name": "github.com/charmbracelet/log",
+        "SPDXID": "SPDXRef-Package-go-module-github.com-charmbracelet-log-230150632de127f8",
+        "versionInfo": "v0.4.0",
+        "supplier": "NOASSERTION",
+        "downloadLocation": "NOASSERTION",
+        "filesAnalyzed": false,
+        "checksums": [
+          {
+            "algorithm": "SHA256",
+            "checksumValue": "1bd6d001cc7cad60364f7a56bf1ed8b4f4cfc20aa993b0faf015f6d48456f193"
+          }
+        ],
+        "sourceInfo": "acquired package info from go module information: bomctl",
+        "licenseConcluded": "NOASSERTION",
+        "licenseDeclared": "NOASSERTION",
+        "copyrightText": "NOASSERTION",
+        "externalRefs": [
+          {
+            "referenceCategory": "SECURITY",
+            "referenceType": "cpe23Type",
+            "referenceLocator": "cpe:2.3:a:charmbracelet:log:v0.4.0:*:*:*:*:*:*:*"
+          },
+          {
+            "referenceCategory": "PACKAGE-MANAGER",
+            "referenceType": "purl",
+            "referenceLocator": "pkg:golang/github.com/charmbracelet/log@v0.4.0"
+          }
+        ]
+      },
+      {
+        "name": "github.com/charmbracelet/x/ansi",
+        "SPDXID": "SPDXRef-Package-go-module-github.com-charmbracelet-x-ansi-a27a9a0d7ea9f3de",
+        "versionInfo": "v0.1.4",
+        "supplier": "NOASSERTION",
+        "downloadLocation": "NOASSERTION",
+        "filesAnalyzed": false,
+        "checksums": [
+          {
+            "algorithm": "SHA256",
+            "checksumValue": "2045370faf9d5b03d2819e87047fafea852e67f9d56b03225a3e7cdf529f88b3"
+          }
+        ],
+        "sourceInfo": "acquired package info from go module information: bomctl",
+        "licenseConcluded": "NOASSERTION",
+        "licenseDeclared": "NOASSERTION",
+        "copyrightText": "NOASSERTION",
+        "externalRefs": [
+          {
+            "referenceCategory": "SECURITY",
+            "referenceType": "cpe23Type",
+            "referenceLocator": "cpe:2.3:a:charmbracelet:x\\/ansi:v0.1.4:*:*:*:*:*:*:*"
+          },
+          {
+            "referenceCategory": "PACKAGE-MANAGER",
+            "referenceType": "purl",
+            "referenceLocator": "pkg:golang/github.com/charmbracelet/x@v0.1.4#ansi"
+          }
+        ]
+      },
+      {
+        "name": "github.com/cloudflare/circl",
+        "SPDXID": "SPDXRef-Package-go-module-github.com-cloudflare-circl-9c57f98a584dee03",
+        "versionInfo": "v1.3.7",
+        "supplier": "NOASSERTION",
+        "downloadLocation": "NOASSERTION",
+        "filesAnalyzed": false,
+        "checksums": [
+          {
+            "algorithm": "SHA256",
+            "checksumValue": "aa50839533f3da7f5fbb9f0cd0d87527f273705a5f8241471d7dcedf9af9bdc5"
+          }
+        ],
+        "sourceInfo": "acquired package info from go module information: bomctl",
+        "licenseConcluded": "NOASSERTION",
+        "licenseDeclared": "NOASSERTION",
+        "copyrightText": "NOASSERTION",
+        "externalRefs": [
+          {
+            "referenceCategory": "SECURITY",
+            "referenceType": "cpe23Type",
+            "referenceLocator": "cpe:2.3:a:cloudflare:circl:v1.3.7:*:*:*:*:*:*:*"
+          },
+          {
+            "referenceCategory": "PACKAGE-MANAGER",
+            "referenceType": "purl",
+            "referenceLocator": "pkg:golang/github.com/cloudflare/circl@v1.3.7"
+          }
+        ]
+      },
+      {
+        "name": "github.com/common-nighthawk/go-figure",
+        "SPDXID": "SPDXRef-Package-go-module-github.com-common-nighthawk-go-figure-8e57ad4319ac392e",
+        "versionInfo": "v0.0.0-20210622060536-734e95fb86be",
+        "supplier": "NOASSERTION",
+        "downloadLocation": "NOASSERTION",
+        "filesAnalyzed": false,
+        "checksums": [
+          {
+            "algorithm": "SHA256",
+            "checksumValue": "27904bda4b2402557d724804b0d417b1c8c868b88e62267be5de1ef7813a75c4"
+          }
+        ],
+        "sourceInfo": "acquired package info from go module information: bomctl",
+        "licenseConcluded": "NOASSERTION",
+        "licenseDeclared": "NOASSERTION",
+        "copyrightText": "NOASSERTION",
+        "externalRefs": [
+          {
+            "referenceCategory": "SECURITY",
+            "referenceType": "cpe23Type",
+            "referenceLocator": "cpe:2.3:a:common-nighthawk:go-figure:v0.0.0-20210622060536-734e95fb86be:*:*:*:*:*:*:*"
+          },
+          {
+            "referenceCategory": "SECURITY",
+            "referenceType": "cpe23Type",
+            "referenceLocator": "cpe:2.3:a:common-nighthawk:go_figure:v0.0.0-20210622060536-734e95fb86be:*:*:*:*:*:*:*"
+          },
+          {
+            "referenceCategory": "SECURITY",
+            "referenceType": "cpe23Type",
+            "referenceLocator": "cpe:2.3:a:common_nighthawk:go-figure:v0.0.0-20210622060536-734e95fb86be:*:*:*:*:*:*:*"
+          },
+          {
+            "referenceCategory": "SECURITY",
+            "referenceType": "cpe23Type",
+            "referenceLocator": "cpe:2.3:a:common_nighthawk:go_figure:v0.0.0-20210622060536-734e95fb86be:*:*:*:*:*:*:*"
+          },
+          {
+            "referenceCategory": "SECURITY",
+            "referenceType": "cpe23Type",
+            "referenceLocator": "cpe:2.3:a:common:go-figure:v0.0.0-20210622060536-734e95fb86be:*:*:*:*:*:*:*"
+          },
+          {
+            "referenceCategory": "SECURITY",
+            "referenceType": "cpe23Type",
+            "referenceLocator": "cpe:2.3:a:common:go_figure:v0.0.0-20210622060536-734e95fb86be:*:*:*:*:*:*:*"
+          },
+          {
+            "referenceCategory": "PACKAGE-MANAGER",
+            "referenceType": "purl",
+            "referenceLocator": "pkg:golang/github.com/common-nighthawk/go-figure@v0.0.0-20210622060536-734e95fb86be"
+          }
+        ]
+      },
+      {
+        "name": "github.com/cyphar/filepath-securejoin",
+        "SPDXID": "SPDXRef-Package-go-module-github.com-cyphar-filepath-securejoin-d3deffed50138a27",
+        "versionInfo": "v0.2.4",
+        "supplier": "NOASSERTION",
+        "downloadLocation": "NOASSERTION",
+        "filesAnalyzed": false,
+        "checksums": [
+          {
+            "algorithm": "SHA256",
+            "checksumValue": "520766edc83b8ba64aeb1df10c5d6812ed677e4c9f1f9dc4b4a7906130b79328"
+          }
+        ],
+        "sourceInfo": "acquired package info from go module information: bomctl",
+        "licenseConcluded": "NOASSERTION",
+        "licenseDeclared": "NOASSERTION",
+        "copyrightText": "NOASSERTION",
+        "externalRefs": [
+          {
+            "referenceCategory": "SECURITY",
+            "referenceType": "cpe23Type",
+            "referenceLocator": "cpe:2.3:a:cyphar:filepath-securejoin:v0.2.4:*:*:*:*:*:*:*"
+          },
+          {
+            "referenceCategory": "SECURITY",
+            "referenceType": "cpe23Type",
+            "referenceLocator": "cpe:2.3:a:cyphar:filepath_securejoin:v0.2.4:*:*:*:*:*:*:*"
+          },
+          {
+            "referenceCategory": "PACKAGE-MANAGER",
+            "referenceType": "purl",
+            "referenceLocator": "pkg:golang/github.com/cyphar/filepath-securejoin@v0.2.4"
+          }
+        ]
+      },
+      {
+        "name": "github.com/dustin/go-humanize",
+        "SPDXID": "SPDXRef-Package-go-module-github.com-dustin-go-humanize-85dfd5c83d6af7b1",
+        "versionInfo": "v1.0.1",
+        "supplier": "NOASSERTION",
+        "downloadLocation": "NOASSERTION",
+        "filesAnalyzed": false,
+        "checksums": [
+          {
+            "algorithm": "SHA256",
+            "checksumValue": "1b392163b4f954d8449301f43d52608f3f9f5f5ae106b47ba514f79839297826"
+          }
+        ],
+        "sourceInfo": "acquired package info from go module information: bomctl",
+        "licenseConcluded": "NOASSERTION",
+        "licenseDeclared": "NOASSERTION",
+        "copyrightText": "NOASSERTION",
+        "externalRefs": [
+          {
+            "referenceCategory": "SECURITY",
+            "referenceType": "cpe23Type",
+            "referenceLocator": "cpe:2.3:a:dustin:go-humanize:v1.0.1:*:*:*:*:*:*:*"
+          },
+          {
+            "referenceCategory": "SECURITY",
+            "referenceType": "cpe23Type",
+            "referenceLocator": "cpe:2.3:a:dustin:go_humanize:v1.0.1:*:*:*:*:*:*:*"
+          },
+          {
+            "referenceCategory": "PACKAGE-MANAGER",
+            "referenceType": "purl",
+            "referenceLocator": "pkg:golang/github.com/dustin/go-humanize@v1.0.1"
+          }
+        ]
+      },
+      {
+        "name": "github.com/emirpasic/gods",
+        "SPDXID": "SPDXRef-Package-go-module-github.com-emirpasic-gods-d22c5cfa09b1d538",
+        "versionInfo": "v1.18.1",
+        "supplier": "NOASSERTION",
+        "downloadLocation": "NOASSERTION",
+        "filesAnalyzed": false,
+        "checksums": [
+          {
+            "algorithm": "SHA256",
+            "checksumValue": "157b621d828318a096d8acf064ac74882d0f426765a2b6207451bd8cf5c9d417"
+          }
+        ],
+        "sourceInfo": "acquired package info from go module information: bomctl",
+        "licenseConcluded": "NOASSERTION",
+        "licenseDeclared": "NOASSERTION",
+        "copyrightText": "NOASSERTION",
+        "externalRefs": [
+          {
+            "referenceCategory": "SECURITY",
+            "referenceType": "cpe23Type",
+            "referenceLocator": "cpe:2.3:a:emirpasic:gods:v1.18.1:*:*:*:*:*:*:*"
+          },
+          {
+            "referenceCategory": "PACKAGE-MANAGER",
+            "referenceType": "purl",
+            "referenceLocator": "pkg:golang/github.com/emirpasic/gods@v1.18.1"
+          }
+        ]
+      },
+      {
+        "name": "github.com/fsnotify/fsnotify",
+        "SPDXID": "SPDXRef-Package-go-module-github.com-fsnotify-fsnotify-447acb8e1eeabbd3",
+        "versionInfo": "v1.7.0",
+        "supplier": "NOASSERTION",
+        "downloadLocation": "NOASSERTION",
+        "filesAnalyzed": false,
+        "checksums": [
+          {
+            "algorithm": "SHA256",
+            "checksumValue": "f091213c56b95b6594ed87de6733cdab330fe8bc2decbdbbd791a0a349e8b2f0"
+          }
+        ],
+        "sourceInfo": "acquired package info from go module information: bomctl",
+        "licenseConcluded": "NOASSERTION",
+        "licenseDeclared": "NOASSERTION",
+        "copyrightText": "NOASSERTION",
+        "externalRefs": [
+          {
+            "referenceCategory": "SECURITY",
+            "referenceType": "cpe23Type",
+            "referenceLocator": "cpe:2.3:a:fsnotify:fsnotify:v1.7.0:*:*:*:*:*:*:*"
+          },
+          {
+            "referenceCategory": "PACKAGE-MANAGER",
+            "referenceType": "purl",
+            "referenceLocator": "pkg:golang/github.com/fsnotify/fsnotify@v1.7.0"
+          }
+        ]
+      },
+      {
+        "name": "github.com/glebarez/go-sqlite",
+        "SPDXID": "SPDXRef-Package-go-module-github.com-glebarez-go-sqlite-ad729fe4f3e5643f",
+        "versionInfo": "v1.22.0",
+        "supplier": "NOASSERTION",
+        "downloadLocation": "NOASSERTION",
+        "filesAnalyzed": false,
+        "checksums": [
+          {
+            "algorithm": "SHA256",
+            "checksumValue": "b8070c261680eabdcb1cc4c580fd1289fce05e0e3ac89920c6acaec9e73eaee4"
+          }
+        ],
+        "sourceInfo": "acquired package info from go module information: bomctl",
+        "licenseConcluded": "NOASSERTION",
+        "licenseDeclared": "NOASSERTION",
+        "copyrightText": "NOASSERTION",
+        "externalRefs": [
+          {
+            "referenceCategory": "SECURITY",
+            "referenceType": "cpe23Type",
+            "referenceLocator": "cpe:2.3:a:glebarez:go-sqlite:v1.22.0:*:*:*:*:*:*:*"
+          },
+          {
+            "referenceCategory": "SECURITY",
+            "referenceType": "cpe23Type",
+            "referenceLocator": "cpe:2.3:a:glebarez:go_sqlite:v1.22.0:*:*:*:*:*:*:*"
+          },
+          {
+            "referenceCategory": "PACKAGE-MANAGER",
+            "referenceType": "purl",
+            "referenceLocator": "pkg:golang/github.com/glebarez/go-sqlite@v1.22.0"
+          }
+        ]
+      },
+      {
+        "name": "github.com/go-git/gcfg",
+        "SPDXID": "SPDXRef-Package-go-module-github.com-go-git-gcfg-ae7765da897ccf62",
+        "versionInfo": "v1.5.1-0.20230307220236-3a3c6141e376",
+        "supplier": "NOASSERTION",
+        "downloadLocation": "NOASSERTION",
+        "filesAnalyzed": false,
+        "checksums": [
+          {
+            "algorithm": "SHA256",
+            "checksumValue": "fb3b3fb4f9a40e41f1dd4eba0c06f4950149ae94baef7d4e69ad768a473e0e22"
+          }
+        ],
+        "sourceInfo": "acquired package info from go module information: bomctl",
+        "licenseConcluded": "NOASSERTION",
+        "licenseDeclared": "NOASSERTION",
+        "copyrightText": "NOASSERTION",
+        "externalRefs": [
+          {
+            "referenceCategory": "SECURITY",
+            "referenceType": "cpe23Type",
+            "referenceLocator": "cpe:2.3:a:go-git:gcfg:v1.5.1-0.20230307220236-3a3c6141e376:*:*:*:*:*:*:*"
+          },
+          {
+            "referenceCategory": "SECURITY",
+            "referenceType": "cpe23Type",
+            "referenceLocator": "cpe:2.3:a:go_git:gcfg:v1.5.1-0.20230307220236-3a3c6141e376:*:*:*:*:*:*:*"
+          },
+          {
+            "referenceCategory": "SECURITY",
+            "referenceType": "cpe23Type",
+            "referenceLocator": "cpe:2.3:a:go:gcfg:v1.5.1-0.20230307220236-3a3c6141e376:*:*:*:*:*:*:*"
+          },
+          {
+            "referenceCategory": "PACKAGE-MANAGER",
+            "referenceType": "purl",
+            "referenceLocator": "pkg:golang/github.com/go-git/gcfg@v1.5.1-0.20230307220236-3a3c6141e376"
+          }
+        ]
+      },
+      {
+        "name": "github.com/go-git/go-billy/v5",
+        "SPDXID": "SPDXRef-Package-go-module-github.com-go-git-go-billy-v5-48d2f61b8785be50",
+        "versionInfo": "v5.5.0",
+        "supplier": "NOASSERTION",
+        "downloadLocation": "NOASSERTION",
+        "filesAnalyzed": false,
+        "checksums": [
+          {
+            "algorithm": "SHA256",
+            "checksumValue": "c84638ca1cc20ee3064aff37a06c62068b51ce1c2136bf15672a61862bbe9935"
+          }
+        ],
+        "sourceInfo": "acquired package info from go module information: bomctl",
+        "licenseConcluded": "NOASSERTION",
+        "licenseDeclared": "NOASSERTION",
+        "copyrightText": "NOASSERTION",
+        "externalRefs": [
+          {
+            "referenceCategory": "SECURITY",
+            "referenceType": "cpe23Type",
+            "referenceLocator": "cpe:2.3:a:go-git:go-billy\\/v5:v5.5.0:*:*:*:*:*:*:*"
+          },
+          {
+            "referenceCategory": "SECURITY",
+            "referenceType": "cpe23Type",
+            "referenceLocator": "cpe:2.3:a:go-git:go_billy\\/v5:v5.5.0:*:*:*:*:*:*:*"
+          },
+          {
+            "referenceCategory": "SECURITY",
+            "referenceType": "cpe23Type",
+            "referenceLocator": "cpe:2.3:a:go_git:go-billy\\/v5:v5.5.0:*:*:*:*:*:*:*"
+          },
+          {
+            "referenceCategory": "SECURITY",
+            "referenceType": "cpe23Type",
+            "referenceLocator": "cpe:2.3:a:go_git:go_billy\\/v5:v5.5.0:*:*:*:*:*:*:*"
+          },
+          {
+            "referenceCategory": "SECURITY",
+            "referenceType": "cpe23Type",
+            "referenceLocator": "cpe:2.3:a:go:go-billy\\/v5:v5.5.0:*:*:*:*:*:*:*"
+          },
+          {
+            "referenceCategory": "SECURITY",
+            "referenceType": "cpe23Type",
+            "referenceLocator": "cpe:2.3:a:go:go_billy\\/v5:v5.5.0:*:*:*:*:*:*:*"
+          },
+          {
+            "referenceCategory": "PACKAGE-MANAGER",
+            "referenceType": "purl",
+            "referenceLocator": "pkg:golang/github.com/go-git/go-billy@v5.5.0#v5"
+          }
+        ]
+      },
+      {
+        "name": "github.com/go-git/go-git/v5",
+        "SPDXID": "SPDXRef-Package-go-module-github.com-go-git-go-git-v5-4d148db8fd7a9c1a",
+        "versionInfo": "v5.12.0",
+        "supplier": "NOASSERTION",
+        "downloadLocation": "NOASSERTION",
+        "filesAnalyzed": false,
+        "checksums": [
+          {
+            "algorithm": "SHA256",
+            "checksumValue": "ecc77e9ddb23af36716dd7510d98c5d78a8af8d379eaccbac24a9a56b8d9b72b"
+          }
+        ],
+        "sourceInfo": "acquired package info from go module information: bomctl",
+        "licenseConcluded": "NOASSERTION",
+        "licenseDeclared": "NOASSERTION",
+        "copyrightText": "NOASSERTION",
+        "externalRefs": [
+          {
+            "referenceCategory": "SECURITY",
+            "referenceType": "cpe23Type",
+            "referenceLocator": "cpe:2.3:a:go-git:go-git\\/v5:v5.12.0:*:*:*:*:*:*:*"
+          },
+          {
+            "referenceCategory": "SECURITY",
+            "referenceType": "cpe23Type",
+            "referenceLocator": "cpe:2.3:a:go-git:go_git\\/v5:v5.12.0:*:*:*:*:*:*:*"
+          },
+          {
+            "referenceCategory": "SECURITY",
+            "referenceType": "cpe23Type",
+            "referenceLocator": "cpe:2.3:a:go_git:go-git\\/v5:v5.12.0:*:*:*:*:*:*:*"
+          },
+          {
+            "referenceCategory": "SECURITY",
+            "referenceType": "cpe23Type",
+            "referenceLocator": "cpe:2.3:a:go_git:go_git\\/v5:v5.12.0:*:*:*:*:*:*:*"
+          },
+          {
+            "referenceCategory": "SECURITY",
+            "referenceType": "cpe23Type",
+            "referenceLocator": "cpe:2.3:a:go:go-git\\/v5:v5.12.0:*:*:*:*:*:*:*"
+          },
+          {
+            "referenceCategory": "SECURITY",
+            "referenceType": "cpe23Type",
+            "referenceLocator": "cpe:2.3:a:go:go_git\\/v5:v5.12.0:*:*:*:*:*:*:*"
+          },
+          {
+            "referenceCategory": "PACKAGE-MANAGER",
+            "referenceType": "purl",
+            "referenceLocator": "pkg:golang/github.com/go-git/go-git@v5.12.0#v5"
+          }
+        ]
+      },
+      {
+        "name": "github.com/go-logfmt/logfmt",
+        "SPDXID": "SPDXRef-Package-go-module-github.com-go-logfmt-logfmt-28cc7b512b5b0b8a",
+        "versionInfo": "v0.6.0",
+        "supplier": "NOASSERTION",
+        "downloadLocation": "NOASSERTION",
+        "filesAnalyzed": false,
+        "checksums": [
+          {
+            "algorithm": "SHA256",
+            "checksumValue": "c06618bb7ba271876a5d582861bbe792b3d55e4b8b335a7589fba00cc11d462e"
+          }
+        ],
+        "sourceInfo": "acquired package info from go module information: bomctl",
+        "licenseConcluded": "NOASSERTION",
+        "licenseDeclared": "NOASSERTION",
+        "copyrightText": "NOASSERTION",
+        "externalRefs": [
+          {
+            "referenceCategory": "SECURITY",
+            "referenceType": "cpe23Type",
+            "referenceLocator": "cpe:2.3:a:go-logfmt:logfmt:v0.6.0:*:*:*:*:*:*:*"
+          },
+          {
+            "referenceCategory": "SECURITY",
+            "referenceType": "cpe23Type",
+            "referenceLocator": "cpe:2.3:a:go_logfmt:logfmt:v0.6.0:*:*:*:*:*:*:*"
+          },
+          {
+            "referenceCategory": "SECURITY",
+            "referenceType": "cpe23Type",
+            "referenceLocator": "cpe:2.3:a:go:logfmt:v0.6.0:*:*:*:*:*:*:*"
+          },
+          {
+            "referenceCategory": "PACKAGE-MANAGER",
+            "referenceType": "purl",
+            "referenceLocator": "pkg:golang/github.com/go-logfmt/logfmt@v0.6.0"
+          }
+        ]
+      },
+      {
+        "name": "github.com/go-openapi/inflect",
+        "SPDXID": "SPDXRef-Package-go-module-github.com-go-openapi-inflect-04ffedb8f70e9170",
+        "versionInfo": "v0.19.0",
+        "supplier": "NOASSERTION",
+        "downloadLocation": "NOASSERTION",
+        "filesAnalyzed": false,
+        "checksums": [
+          {
+            "algorithm": "SHA256",
+            "checksumValue": "f63087f6c70a21b1de57d9b5d9298f8a549ccfa92b0f12916ac34d48d3d7bbfe"
+          }
+        ],
+        "sourceInfo": "acquired package info from go module information: bomctl",
+        "licenseConcluded": "NOASSERTION",
+        "licenseDeclared": "NOASSERTION",
+        "copyrightText": "NOASSERTION",
+        "externalRefs": [
+          {
+            "referenceCategory": "SECURITY",
+            "referenceType": "cpe23Type",
+            "referenceLocator": "cpe:2.3:a:go-openapi:inflect:v0.19.0:*:*:*:*:*:*:*"
+          },
+          {
+            "referenceCategory": "SECURITY",
+            "referenceType": "cpe23Type",
+            "referenceLocator": "cpe:2.3:a:go_openapi:inflect:v0.19.0:*:*:*:*:*:*:*"
+          },
+          {
+            "referenceCategory": "SECURITY",
+            "referenceType": "cpe23Type",
+            "referenceLocator": "cpe:2.3:a:go:inflect:v0.19.0:*:*:*:*:*:*:*"
+          },
+          {
+            "referenceCategory": "PACKAGE-MANAGER",
+            "referenceType": "purl",
+            "referenceLocator": "pkg:golang/github.com/go-openapi/inflect@v0.19.0"
+          }
+        ]
+      },
+      {
+        "name": "github.com/golang/groupcache",
+        "SPDXID": "SPDXRef-Package-go-module-github.com-golang-groupcache-0dceeab7e0e706b1",
+        "versionInfo": "v0.0.0-20210331224755-41bb18bfe9da",
+        "supplier": "NOASSERTION",
+        "downloadLocation": "NOASSERTION",
+        "filesAnalyzed": false,
+        "checksums": [
+          {
+            "algorithm": "SHA256",
+            "checksumValue": "a08e710aab02a39eb897c88d53e0f00797a9c66b1aa81fab8462f49b98ed62a1"
+          }
+        ],
+        "sourceInfo": "acquired package info from go module information: bomctl",
+        "licenseConcluded": "NOASSERTION",
+        "licenseDeclared": "NOASSERTION",
+        "copyrightText": "NOASSERTION",
+        "externalRefs": [
+          {
+            "referenceCategory": "SECURITY",
+            "referenceType": "cpe23Type",
+            "referenceLocator": "cpe:2.3:a:golang:groupcache:v0.0.0-20210331224755-41bb18bfe9da:*:*:*:*:*:*:*"
+          },
+          {
+            "referenceCategory": "PACKAGE-MANAGER",
+            "referenceType": "purl",
+            "referenceLocator": "pkg:golang/github.com/golang/groupcache@v0.0.0-20210331224755-41bb18bfe9da"
+          }
+        ]
+      },
+      {
+        "name": "github.com/google/go-cmp",
+        "SPDXID": "SPDXRef-Package-go-module-github.com-google-go-cmp-b6d176695d69491a",
+        "versionInfo": "v0.6.0",
+        "supplier": "NOASSERTION",
+        "downloadLocation": "NOASSERTION",
+        "filesAnalyzed": false,
+        "checksums": [
+          {
+            "algorithm": "SHA256",
+            "checksumValue": "a1fca1c6f5dc66132c539ba56c588b2a5fd7045a84d464aaedab6ef2d0264d12"
+          }
+        ],
+        "sourceInfo": "acquired package info from go module information: bomctl",
+        "licenseConcluded": "NOASSERTION",
+        "licenseDeclared": "NOASSERTION",
+        "copyrightText": "NOASSERTION",
+        "externalRefs": [
+          {
+            "referenceCategory": "SECURITY",
+            "referenceType": "cpe23Type",
+            "referenceLocator": "cpe:2.3:a:google:go-cmp:v0.6.0:*:*:*:*:*:*:*"
+          },
+          {
+            "referenceCategory": "SECURITY",
+            "referenceType": "cpe23Type",
+            "referenceLocator": "cpe:2.3:a:google:go_cmp:v0.6.0:*:*:*:*:*:*:*"
+          },
+          {
+            "referenceCategory": "PACKAGE-MANAGER",
+            "referenceType": "purl",
+            "referenceLocator": "pkg:golang/github.com/google/go-cmp@v0.6.0"
+          }
+        ]
+      },
+      {
+        "name": "github.com/google/uuid",
+        "SPDXID": "SPDXRef-Package-go-module-github.com-google-uuid-96a219fc8f765731",
+        "versionInfo": "v1.6.0",
+        "supplier": "NOASSERTION",
+        "downloadLocation": "NOASSERTION",
+        "filesAnalyzed": false,
+        "checksums": [
+          {
+            "algorithm": "SHA256",
+            "checksumValue": "348bda24330eb231c0f27d630212d2833ac0cf2d4782bfa136b6f9edefbde05d"
+          }
+        ],
+        "sourceInfo": "acquired package info from go module information: bomctl",
+        "licenseConcluded": "NOASSERTION",
+        "licenseDeclared": "NOASSERTION",
+        "copyrightText": "NOASSERTION",
+        "externalRefs": [
+          {
+            "referenceCategory": "SECURITY",
+            "referenceType": "cpe23Type",
+            "referenceLocator": "cpe:2.3:a:google:uuid:v1.6.0:*:*:*:*:*:*:*"
+          },
+          {
+            "referenceCategory": "PACKAGE-MANAGER",
+            "referenceType": "purl",
+            "referenceLocator": "pkg:golang/github.com/google/uuid@v1.6.0"
+          }
+        ]
+      },
+      {
+        "name": "github.com/hashicorp/hcl",
+        "SPDXID": "SPDXRef-Package-go-module-github.com-hashicorp-hcl-aa3f0391aca480a4",
+        "versionInfo": "v1.0.0",
+        "supplier": "NOASSERTION",
+        "downloadLocation": "NOASSERTION",
+        "filesAnalyzed": false,
+        "checksums": [
+          {
+            "algorithm": "SHA256",
+            "checksumValue": "d009e5ce3a62e2f11ab1378d167da62c98134b0b74fbab1fb224c6f2a7161b1e"
+          }
+        ],
+        "sourceInfo": "acquired package info from go module information: bomctl",
+        "licenseConcluded": "NOASSERTION",
+        "licenseDeclared": "NOASSERTION",
+        "copyrightText": "NOASSERTION",
+        "externalRefs": [
+          {
+            "referenceCategory": "SECURITY",
+            "referenceType": "cpe23Type",
+            "referenceLocator": "cpe:2.3:a:hashicorp:hcl:v1.0.0:*:*:*:*:*:*:*"
+          },
+          {
+            "referenceCategory": "PACKAGE-MANAGER",
+            "referenceType": "purl",
+            "referenceLocator": "pkg:golang/github.com/hashicorp/hcl@v1.0.0"
+          }
+        ]
+      },
+      {
+        "name": "github.com/hashicorp/hcl/v2",
+        "SPDXID": "SPDXRef-Package-go-module-github.com-hashicorp-hcl-v2-55ff1dce30248d44",
+        "versionInfo": "v2.13.0",
+        "supplier": "NOASSERTION",
+        "downloadLocation": "NOASSERTION",
+        "filesAnalyzed": false,
+        "checksums": [
+          {
+            "algorithm": "SHA256",
+            "checksumValue": "d00a5a76ed70e8cd75772185c569e686170c8e46c088a0afec6d6bff642008d7"
+          }
+        ],
+        "sourceInfo": "acquired package info from go module information: bomctl",
+        "licenseConcluded": "NOASSERTION",
+        "licenseDeclared": "NOASSERTION",
+        "copyrightText": "NOASSERTION",
+        "externalRefs": [
+          {
+            "referenceCategory": "SECURITY",
+            "referenceType": "cpe23Type",
+            "referenceLocator": "cpe:2.3:a:hashicorp:hcl\\/v2:v2.13.0:*:*:*:*:*:*:*"
+          },
+          {
+            "referenceCategory": "PACKAGE-MANAGER",
+            "referenceType": "purl",
+            "referenceLocator": "pkg:golang/github.com/hashicorp/hcl@v2.13.0#v2"
+          }
+        ]
+      },
+      {
+        "name": "github.com/jbenet/go-context",
+        "SPDXID": "SPDXRef-Package-go-module-github.com-jbenet-go-context-27b65da1f0dfe16d",
+        "versionInfo": "v0.0.0-20150711004518-d14ea06fba99",
+        "supplier": "NOASSERTION",
+        "downloadLocation": "NOASSERTION",
+        "filesAnalyzed": false,
+        "checksums": [
+          {
+            "algorithm": "SHA256",
+            "checksumValue": "05048578f03545624e968707e85c72f0c9b00edfb25506142ca7cdd11a1337c0"
+          }
+        ],
+        "sourceInfo": "acquired package info from go module information: bomctl",
+        "licenseConcluded": "NOASSERTION",
+        "licenseDeclared": "NOASSERTION",
+        "copyrightText": "NOASSERTION",
+        "externalRefs": [
+          {
+            "referenceCategory": "SECURITY",
+            "referenceType": "cpe23Type",
+            "referenceLocator": "cpe:2.3:a:jbenet:go-context:v0.0.0-20150711004518-d14ea06fba99:*:*:*:*:*:*:*"
+          },
+          {
+            "referenceCategory": "SECURITY",
+            "referenceType": "cpe23Type",
+            "referenceLocator": "cpe:2.3:a:jbenet:go_context:v0.0.0-20150711004518-d14ea06fba99:*:*:*:*:*:*:*"
+          },
+          {
+            "referenceCategory": "PACKAGE-MANAGER",
+            "referenceType": "purl",
+            "referenceLocator": "pkg:golang/github.com/jbenet/go-context@v0.0.0-20150711004518-d14ea06fba99"
+          }
+        ]
+      },
+      {
+        "name": "github.com/jdx/go-netrc",
+        "SPDXID": "SPDXRef-Package-go-module-github.com-jdx-go-netrc-41e623eea0949ae0",
+        "versionInfo": "v1.0.0",
+        "supplier": "NOASSERTION",
+        "downloadLocation": "NOASSERTION",
+        "filesAnalyzed": false,
+        "checksums": [
+          {
+            "algorithm": "SHA256",
+            "checksumValue": "41b2cc2f20991a3d0d03c825021c54a5fd730e0e9cc675a03016e3ab8d16d204"
+          }
+        ],
+        "sourceInfo": "acquired package info from go module information: bomctl",
+        "licenseConcluded": "NOASSERTION",
+        "licenseDeclared": "NOASSERTION",
+        "copyrightText": "NOASSERTION",
+        "externalRefs": [
+          {
+            "referenceCategory": "SECURITY",
+            "referenceType": "cpe23Type",
+            "referenceLocator": "cpe:2.3:a:jdx:go-netrc:v1.0.0:*:*:*:*:*:*:*"
+          },
+          {
+            "referenceCategory": "SECURITY",
+            "referenceType": "cpe23Type",
+            "referenceLocator": "cpe:2.3:a:jdx:go_netrc:v1.0.0:*:*:*:*:*:*:*"
+          },
+          {
+            "referenceCategory": "PACKAGE-MANAGER",
+            "referenceType": "purl",
+            "referenceLocator": "pkg:golang/github.com/jdx/go-netrc@v1.0.0"
+          }
+        ]
+      },
+      {
+        "name": "github.com/kevinburke/ssh_config",
+        "SPDXID": "SPDXRef-Package-go-module-github.com-kevinburke-ssh-config-80389f8e5464d1d7",
+        "versionInfo": "v1.2.0",
+        "supplier": "NOASSERTION",
+        "downloadLocation": "NOASSERTION",
+        "filesAnalyzed": false,
+        "checksums": [
+          {
+            "algorithm": "SHA256",
+            "checksumValue": "c79f381634c6c07cccc2f1f1d7c3d7c5b055cdf9f1a201da011794e207f5ddae"
+          }
+        ],
+        "sourceInfo": "acquired package info from go module information: bomctl",
+        "licenseConcluded": "NOASSERTION",
+        "licenseDeclared": "NOASSERTION",
+        "copyrightText": "NOASSERTION",
+        "externalRefs": [
+          {
+            "referenceCategory": "SECURITY",
+            "referenceType": "cpe23Type",
+            "referenceLocator": "cpe:2.3:a:kevinburke:ssh-config:v1.2.0:*:*:*:*:*:*:*"
+          },
+          {
+            "referenceCategory": "SECURITY",
+            "referenceType": "cpe23Type",
+            "referenceLocator": "cpe:2.3:a:kevinburke:ssh_config:v1.2.0:*:*:*:*:*:*:*"
+          },
+          {
+            "referenceCategory": "PACKAGE-MANAGER",
+            "referenceType": "purl",
+            "referenceLocator": "pkg:golang/github.com/kevinburke/ssh_config@v1.2.0"
+          }
+        ]
+      },
+      {
+        "name": "github.com/lucasb-eyer/go-colorful",
+        "SPDXID": "SPDXRef-Package-go-module-github.com-lucasb-eyer-go-colorful-fbed168999279944",
+        "versionInfo": "v1.2.0",
+        "supplier": "NOASSERTION",
+        "downloadLocation": "NOASSERTION",
+        "filesAnalyzed": false,
+        "checksums": [
+          {
+            "algorithm": "SHA256",
+            "checksumValue": "d679e918eae1c9966e3727eed508ca89420243be3edc534237af408fa2bb9e46"
+          }
+        ],
+        "sourceInfo": "acquired package info from go module information: bomctl",
+        "licenseConcluded": "NOASSERTION",
+        "licenseDeclared": "NOASSERTION",
+        "copyrightText": "NOASSERTION",
+        "externalRefs": [
+          {
+            "referenceCategory": "SECURITY",
+            "referenceType": "cpe23Type",
+            "referenceLocator": "cpe:2.3:a:lucasb-eyer:go-colorful:v1.2.0:*:*:*:*:*:*:*"
+          },
+          {
+            "referenceCategory": "SECURITY",
+            "referenceType": "cpe23Type",
+            "referenceLocator": "cpe:2.3:a:lucasb-eyer:go_colorful:v1.2.0:*:*:*:*:*:*:*"
+          },
+          {
+            "referenceCategory": "SECURITY",
+            "referenceType": "cpe23Type",
+            "referenceLocator": "cpe:2.3:a:lucasb_eyer:go-colorful:v1.2.0:*:*:*:*:*:*:*"
+          },
+          {
+            "referenceCategory": "SECURITY",
+            "referenceType": "cpe23Type",
+            "referenceLocator": "cpe:2.3:a:lucasb_eyer:go_colorful:v1.2.0:*:*:*:*:*:*:*"
+          },
+          {
+            "referenceCategory": "SECURITY",
+            "referenceType": "cpe23Type",
+            "referenceLocator": "cpe:2.3:a:lucasb:go-colorful:v1.2.0:*:*:*:*:*:*:*"
+          },
+          {
+            "referenceCategory": "SECURITY",
+            "referenceType": "cpe23Type",
+            "referenceLocator": "cpe:2.3:a:lucasb:go_colorful:v1.2.0:*:*:*:*:*:*:*"
+          },
+          {
+            "referenceCategory": "PACKAGE-MANAGER",
+            "referenceType": "purl",
+            "referenceLocator": "pkg:golang/github.com/lucasb-eyer/go-colorful@v1.2.0"
+          }
+        ]
+      },
+      {
+        "name": "github.com/magiconair/properties",
+        "SPDXID": "SPDXRef-Package-go-module-github.com-magiconair-properties-bb59395879b78628",
+        "versionInfo": "v1.8.7",
+        "supplier": "NOASSERTION",
+        "downloadLocation": "NOASSERTION",
+        "filesAnalyzed": false,
+        "checksums": [
+          {
+            "algorithm": "SHA256",
+            "checksumValue": "21e4176408907292fd9a07007b536ee9c5fd2cbc3a1311072a337455076f3c36"
+          }
+        ],
+        "sourceInfo": "acquired package info from go module information: bomctl",
+        "licenseConcluded": "NOASSERTION",
+        "licenseDeclared": "NOASSERTION",
+        "copyrightText": "NOASSERTION",
+        "externalRefs": [
+          {
+            "referenceCategory": "SECURITY",
+            "referenceType": "cpe23Type",
+            "referenceLocator": "cpe:2.3:a:magiconair:properties:v1.8.7:*:*:*:*:*:*:*"
+          },
+          {
+            "referenceCategory": "PACKAGE-MANAGER",
+            "referenceType": "purl",
+            "referenceLocator": "pkg:golang/github.com/magiconair/properties@v1.8.7"
+          }
+        ]
+      },
+      {
+        "name": "github.com/mattn/go-isatty",
+        "SPDXID": "SPDXRef-Package-go-module-github.com-mattn-go-isatty-7e215fce8e704dd4",
+        "versionInfo": "v0.0.20",
+        "supplier": "NOASSERTION",
+        "downloadLocation": "NOASSERTION",
+        "filesAnalyzed": false,
+        "checksums": [
+          {
+            "algorithm": "SHA256",
+            "checksumValue": "c5f0f4883b842a70e4974deae258a607ebc7f86c4b12d2ff8dbe315494965846"
+          }
+        ],
+        "sourceInfo": "acquired package info from go module information: bomctl",
+        "licenseConcluded": "NOASSERTION",
+        "licenseDeclared": "NOASSERTION",
+        "copyrightText": "NOASSERTION",
+        "externalRefs": [
+          {
+            "referenceCategory": "SECURITY",
+            "referenceType": "cpe23Type",
+            "referenceLocator": "cpe:2.3:a:mattn:go-isatty:v0.0.20:*:*:*:*:*:*:*"
+          },
+          {
+            "referenceCategory": "SECURITY",
+            "referenceType": "cpe23Type",
+            "referenceLocator": "cpe:2.3:a:mattn:go_isatty:v0.0.20:*:*:*:*:*:*:*"
+          },
+          {
+            "referenceCategory": "PACKAGE-MANAGER",
+            "referenceType": "purl",
+            "referenceLocator": "pkg:golang/github.com/mattn/go-isatty@v0.0.20"
+          }
+        ]
+      },
+      {
+        "name": "github.com/mattn/go-runewidth",
+        "SPDXID": "SPDXRef-Package-go-module-github.com-mattn-go-runewidth-ce6e3b6b4e625eff",
+        "versionInfo": "v0.0.15",
+        "supplier": "NOASSERTION",
+        "downloadLocation": "NOASSERTION",
+        "filesAnalyzed": false,
+        "checksums": [
+          {
+            "algorithm": "SHA256",
+            "checksumValue": "50d023c1b53d979e130372b3bea2c6c705a31e63200545610624e37a56608375"
+          }
+        ],
+        "sourceInfo": "acquired package info from go module information: bomctl",
+        "licenseConcluded": "NOASSERTION",
+        "licenseDeclared": "NOASSERTION",
+        "copyrightText": "NOASSERTION",
+        "externalRefs": [
+          {
+            "referenceCategory": "SECURITY",
+            "referenceType": "cpe23Type",
+            "referenceLocator": "cpe:2.3:a:mattn:go-runewidth:v0.0.15:*:*:*:*:*:*:*"
+          },
+          {
+            "referenceCategory": "SECURITY",
+            "referenceType": "cpe23Type",
+            "referenceLocator": "cpe:2.3:a:mattn:go_runewidth:v0.0.15:*:*:*:*:*:*:*"
+          },
+          {
+            "referenceCategory": "PACKAGE-MANAGER",
+            "referenceType": "purl",
+            "referenceLocator": "pkg:golang/github.com/mattn/go-runewidth@v0.0.15"
+          }
+        ]
+      },
+      {
+        "name": "github.com/mitchellh/go-wordwrap",
+        "SPDXID": "SPDXRef-Package-go-module-github.com-mitchellh-go-wordwrap-9653b68335c34a14",
+        "versionInfo": "v0.0.0-20150314170334-ad45545899c7",
+        "supplier": "NOASSERTION",
+        "downloadLocation": "NOASSERTION",
+        "filesAnalyzed": false,
+        "checksums": [
+          {
+            "algorithm": "SHA256",
+            "checksumValue": "0e9389d876330aff0b64fd7921d986f987700f696e54f1c84d5f7a4e48ab3413"
+          }
+        ],
+        "sourceInfo": "acquired package info from go module information: bomctl",
+        "licenseConcluded": "NOASSERTION",
+        "licenseDeclared": "NOASSERTION",
+        "copyrightText": "NOASSERTION",
+        "externalRefs": [
+          {
+            "referenceCategory": "SECURITY",
+            "referenceType": "cpe23Type",
+            "referenceLocator": "cpe:2.3:a:mitchellh:go-wordwrap:v0.0.0-20150314170334-ad45545899c7:*:*:*:*:*:*:*"
+          },
+          {
+            "referenceCategory": "SECURITY",
+            "referenceType": "cpe23Type",
+            "referenceLocator": "cpe:2.3:a:mitchellh:go_wordwrap:v0.0.0-20150314170334-ad45545899c7:*:*:*:*:*:*:*"
+          },
+          {
+            "referenceCategory": "PACKAGE-MANAGER",
+            "referenceType": "purl",
+            "referenceLocator": "pkg:golang/github.com/mitchellh/go-wordwrap@v0.0.0-20150314170334-ad45545899c7"
+          }
+        ]
+      },
+      {
+        "name": "github.com/mitchellh/mapstructure",
+        "SPDXID": "SPDXRef-Package-go-module-github.com-mitchellh-mapstructure-ce92bf8494f7c701",
+        "versionInfo": "v1.5.0",
+        "supplier": "NOASSERTION",
+        "downloadLocation": "NOASSERTION",
+        "filesAnalyzed": false,
+        "checksums": [
+          {
+            "algorithm": "SHA256",
+            "checksumValue": "8de32c648604ff4f6c58b6b3e373cbec6cba46e3230f6789572b9a73967685d6"
+          }
+        ],
+        "sourceInfo": "acquired package info from go module information: bomctl",
+        "licenseConcluded": "NOASSERTION",
+        "licenseDeclared": "NOASSERTION",
+        "copyrightText": "NOASSERTION",
+        "externalRefs": [
+          {
+            "referenceCategory": "SECURITY",
+            "referenceType": "cpe23Type",
+            "referenceLocator": "cpe:2.3:a:mitchellh:mapstructure:v1.5.0:*:*:*:*:*:*:*"
+          },
+          {
+            "referenceCategory": "PACKAGE-MANAGER",
+            "referenceType": "purl",
+            "referenceLocator": "pkg:golang/github.com/mitchellh/mapstructure@v1.5.0"
+          }
+        ]
+      },
+      {
+        "name": "github.com/muesli/termenv",
+        "SPDXID": "SPDXRef-Package-go-module-github.com-muesli-termenv-cfc0e1203c415e26",
+        "versionInfo": "v0.15.2",
+        "supplier": "NOASSERTION",
+        "downloadLocation": "NOASSERTION",
+        "filesAnalyzed": false,
+        "checksums": [
+          {
+            "algorithm": "SHA256",
+            "checksumValue": "1a885cbb2488d10988df037c3a4f4fb4a1a482414893bcba5696f93efad8f96a"
+          }
+        ],
+        "sourceInfo": "acquired package info from go module information: bomctl",
+        "licenseConcluded": "NOASSERTION",
+        "licenseDeclared": "NOASSERTION",
+        "copyrightText": "NOASSERTION",
+        "externalRefs": [
+          {
+            "referenceCategory": "SECURITY",
+            "referenceType": "cpe23Type",
+            "referenceLocator": "cpe:2.3:a:muesli:termenv:v0.15.2:*:*:*:*:*:*:*"
+          },
+          {
+            "referenceCategory": "PACKAGE-MANAGER",
+            "referenceType": "purl",
+            "referenceLocator": "pkg:golang/github.com/muesli/termenv@v0.15.2"
+          }
+        ]
+      },
+      {
+        "name": "github.com/opencontainers/go-digest",
+        "SPDXID": "SPDXRef-Package-go-module-github.com-opencontainers-go-digest-acdedc5890713dd2",
+        "versionInfo": "v1.0.0",
+        "supplier": "NOASSERTION",
+        "downloadLocation": "NOASSERTION",
+        "filesAnalyzed": false,
+        "checksums": [
+          {
+            "algorithm": "SHA256",
+            "checksumValue": "6a93945ace755b93e586ec86cb3f4509e78120e50303fea75bc3a2ff23a18795"
+          }
+        ],
+        "sourceInfo": "acquired package info from go module information: bomctl",
+        "licenseConcluded": "NOASSERTION",
+        "licenseDeclared": "NOASSERTION",
+        "copyrightText": "NOASSERTION",
+        "externalRefs": [
+          {
+            "referenceCategory": "SECURITY",
+            "referenceType": "cpe23Type",
+            "referenceLocator": "cpe:2.3:a:opencontainers:go-digest:v1.0.0:*:*:*:*:*:*:*"
+          },
+          {
+            "referenceCategory": "SECURITY",
+            "referenceType": "cpe23Type",
+            "referenceLocator": "cpe:2.3:a:opencontainers:go_digest:v1.0.0:*:*:*:*:*:*:*"
+          },
+          {
+            "referenceCategory": "PACKAGE-MANAGER",
+            "referenceType": "purl",
+            "referenceLocator": "pkg:golang/github.com/opencontainers/go-digest@v1.0.0"
+          }
+        ]
+      },
+      {
+        "name": "github.com/opencontainers/image-spec",
+        "SPDXID": "SPDXRef-Package-go-module-github.com-opencontainers-image-spec-7d27d7681ca52fa3",
+        "versionInfo": "v1.1.0",
+        "supplier": "NOASSERTION",
+        "downloadLocation": "NOASSERTION",
+        "filesAnalyzed": false,
+        "checksums": [
+          {
+            "algorithm": "SHA256",
+            "checksumValue": "f121bbfefc002e7e7895507fd3267f30cc2116b3d8b6910741bd88a56b02cee8"
+          }
+        ],
+        "sourceInfo": "acquired package info from go module information: bomctl",
+        "licenseConcluded": "NOASSERTION",
+        "licenseDeclared": "NOASSERTION",
+        "copyrightText": "NOASSERTION",
+        "externalRefs": [
+          {
+            "referenceCategory": "SECURITY",
+            "referenceType": "cpe23Type",
+            "referenceLocator": "cpe:2.3:a:opencontainers:image-spec:v1.1.0:*:*:*:*:*:*:*"
+          },
+          {
+            "referenceCategory": "SECURITY",
+            "referenceType": "cpe23Type",
+            "referenceLocator": "cpe:2.3:a:opencontainers:image_spec:v1.1.0:*:*:*:*:*:*:*"
+          },
+          {
+            "referenceCategory": "PACKAGE-MANAGER",
+            "referenceType": "purl",
+            "referenceLocator": "pkg:golang/github.com/opencontainers/image-spec@v1.1.0"
+          }
+        ]
+      },
+      {
+        "name": "github.com/pelletier/go-toml/v2",
+        "SPDXID": "SPDXRef-Package-go-module-github.com-pelletier-go-toml-v2-0c4beda42b47b30f",
+        "versionInfo": "v2.2.2",
+        "supplier": "NOASSERTION",
+        "downloadLocation": "NOASSERTION",
+        "filesAnalyzed": false,
+        "checksums": [
+          {
+            "algorithm": "SHA256",
+            "checksumValue": "698522753ee4ef73dc97d9dbda049cbbb352aca0921c80c4f3d6f7fba5aaf8b3"
+          }
+        ],
+        "sourceInfo": "acquired package info from go module information: bomctl",
+        "licenseConcluded": "NOASSERTION",
+        "licenseDeclared": "NOASSERTION",
+        "copyrightText": "NOASSERTION",
+        "externalRefs": [
+          {
+            "referenceCategory": "SECURITY",
+            "referenceType": "cpe23Type",
+            "referenceLocator": "cpe:2.3:a:pelletier:go-toml\\/v2:v2.2.2:*:*:*:*:*:*:*"
+          },
+          {
+            "referenceCategory": "SECURITY",
+            "referenceType": "cpe23Type",
+            "referenceLocator": "cpe:2.3:a:pelletier:go_toml\\/v2:v2.2.2:*:*:*:*:*:*:*"
+          },
+          {
+            "referenceCategory": "PACKAGE-MANAGER",
+            "referenceType": "purl",
+            "referenceLocator": "pkg:golang/github.com/pelletier/go-toml@v2.2.2#v2"
+          }
+        ]
+      },
+      {
+        "name": "github.com/pjbgf/sha1cd",
+        "SPDXID": "SPDXRef-Package-go-module-github.com-pjbgf-sha1cd-b19c6cb88557f8bd",
+        "versionInfo": "v0.3.0",
+        "supplier": "NOASSERTION",
+        "downloadLocation": "NOASSERTION",
+        "filesAnalyzed": false,
+        "checksums": [
+          {
+            "algorithm": "SHA256",
+            "checksumValue": "e03e575e651405497fc50e888c290401ba97b2492aff83bb2e61a7d00a8c0ece"
+          }
+        ],
+        "sourceInfo": "acquired package info from go module information: bomctl",
+        "licenseConcluded": "NOASSERTION",
+        "licenseDeclared": "NOASSERTION",
+        "copyrightText": "NOASSERTION",
+        "externalRefs": [
+          {
+            "referenceCategory": "SECURITY",
+            "referenceType": "cpe23Type",
+            "referenceLocator": "cpe:2.3:a:pjbgf:sha1cd:v0.3.0:*:*:*:*:*:*:*"
+          },
+          {
+            "referenceCategory": "PACKAGE-MANAGER",
+            "referenceType": "purl",
+            "referenceLocator": "pkg:golang/github.com/pjbgf/sha1cd@v0.3.0"
+          }
+        ]
+      },
+      {
+        "name": "github.com/protobom/protobom",
+        "SPDXID": "SPDXRef-Package-go-module-github.com-protobom-protobom-c6092a35d4046627",
+        "versionInfo": "v0.4.3",
+        "supplier": "NOASSERTION",
+        "downloadLocation": "NOASSERTION",
+        "filesAnalyzed": false,
+        "checksums": [
+          {
+            "algorithm": "SHA256",
+            "checksumValue": "675a2283fcd550d83514afdc0ea5bd30519d4f4b61775d85bdc5fab7c8d4507f"
+          }
+        ],
+        "sourceInfo": "acquired package info from go module information: bomctl",
+        "licenseConcluded": "NOASSERTION",
+        "licenseDeclared": "NOASSERTION",
+        "copyrightText": "NOASSERTION",
+        "externalRefs": [
+          {
+            "referenceCategory": "SECURITY",
+            "referenceType": "cpe23Type",
+            "referenceLocator": "cpe:2.3:a:protobom:protobom:v0.4.3:*:*:*:*:*:*:*"
+          },
+          {
+            "referenceCategory": "PACKAGE-MANAGER",
+            "referenceType": "purl",
+            "referenceLocator": "pkg:golang/github.com/protobom/protobom@v0.4.3"
+          }
+        ]
+      },
+      {
+        "name": "github.com/protobom/storage",
+        "SPDXID": "SPDXRef-Package-go-module-github.com-protobom-storage-f53e9cde5f8d751c",
+        "versionInfo": "v0.1.3",
+        "supplier": "NOASSERTION",
+        "downloadLocation": "NOASSERTION",
+        "filesAnalyzed": false,
+        "checksums": [
+          {
+            "algorithm": "SHA256",
+            "checksumValue": "e45a15e74742f49fd4b4ec726a77bb30165727cbff9427473c661d0f1f25a014"
+          }
+        ],
+        "sourceInfo": "acquired package info from go module information: bomctl",
+        "licenseConcluded": "NOASSERTION",
+        "licenseDeclared": "NOASSERTION",
+        "copyrightText": "NOASSERTION",
+        "externalRefs": [
+          {
+            "referenceCategory": "SECURITY",
+            "referenceType": "cpe23Type",
+            "referenceLocator": "cpe:2.3:a:protobom:storage:v0.1.3:*:*:*:*:*:*:*"
+          },
+          {
+            "referenceCategory": "PACKAGE-MANAGER",
+            "referenceType": "purl",
+            "referenceLocator": "pkg:golang/github.com/protobom/storage@v0.1.3"
+          }
+        ]
+      },
+      {
+        "name": "github.com/remyoudompheng/bigfft",
+        "SPDXID": "SPDXRef-Package-go-module-github.com-remyoudompheng-bigfft-af00bbfe7ea65ca7",
+        "versionInfo": "v0.0.0-20230129092748-24d4a6f8daec",
+        "supplier": "NOASSERTION",
+        "downloadLocation": "NOASSERTION",
+        "filesAnalyzed": false,
+        "checksums": [
+          {
+            "algorithm": "SHA256",
+            "checksumValue": "5b4f4854973de2272ae0d8d8ddc95becb93c3b5a89f01741105f33d226d4d2b1"
+          }
+        ],
+        "sourceInfo": "acquired package info from go module information: bomctl",
+        "licenseConcluded": "NOASSERTION",
+        "licenseDeclared": "NOASSERTION",
+        "copyrightText": "NOASSERTION",
+        "externalRefs": [
+          {
+            "referenceCategory": "SECURITY",
+            "referenceType": "cpe23Type",
+            "referenceLocator": "cpe:2.3:a:remyoudompheng:bigfft:v0.0.0-20230129092748-24d4a6f8daec:*:*:*:*:*:*:*"
+          },
+          {
+            "referenceCategory": "PACKAGE-MANAGER",
+            "referenceType": "purl",
+            "referenceLocator": "pkg:golang/github.com/remyoudompheng/bigfft@v0.0.0-20230129092748-24d4a6f8daec"
+          }
+        ]
+      },
+      {
+        "name": "github.com/rivo/uniseg",
+        "SPDXID": "SPDXRef-Package-go-module-github.com-rivo-uniseg-6488b24fc2fd4ca4",
+        "versionInfo": "v0.4.7",
+        "supplier": "NOASSERTION",
+        "downloadLocation": "NOASSERTION",
+        "filesAnalyzed": false,
+        "checksums": [
+          {
+            "algorithm": "SHA256",
+            "checksumValue": "59476f916f2e121ad87cb0b8673769236cedc4fd48e7cdbee3d39ce4cabae154"
+          }
+        ],
+        "sourceInfo": "acquired package info from go module information: bomctl",
+        "licenseConcluded": "NOASSERTION",
+        "licenseDeclared": "NOASSERTION",
+        "copyrightText": "NOASSERTION",
+        "externalRefs": [
+          {
+            "referenceCategory": "SECURITY",
+            "referenceType": "cpe23Type",
+            "referenceLocator": "cpe:2.3:a:rivo:uniseg:v0.4.7:*:*:*:*:*:*:*"
+          },
+          {
+            "referenceCategory": "PACKAGE-MANAGER",
+            "referenceType": "purl",
+            "referenceLocator": "pkg:golang/github.com/rivo/uniseg@v0.4.7"
+          }
+        ]
+      },
+      {
+        "name": "github.com/sagikazarmark/slog-shim",
+        "SPDXID": "SPDXRef-Package-go-module-github.com-sagikazarmark-slog-shim-f8702e09f858dfb5",
+        "versionInfo": "v0.1.0",
+        "supplier": "NOASSERTION",
+        "downloadLocation": "NOASSERTION",
+        "filesAnalyzed": false,
+        "checksums": [
+          {
+            "algorithm": "SHA256",
+            "checksumValue": "7620c19d434af4dff7e783e0af1332c179c0c04af541970eafa82da3eba08d81"
+          }
+        ],
+        "sourceInfo": "acquired package info from go module information: bomctl",
+        "licenseConcluded": "NOASSERTION",
+        "licenseDeclared": "NOASSERTION",
+        "copyrightText": "NOASSERTION",
+        "externalRefs": [
+          {
+            "referenceCategory": "SECURITY",
+            "referenceType": "cpe23Type",
+            "referenceLocator": "cpe:2.3:a:sagikazarmark:slog-shim:v0.1.0:*:*:*:*:*:*:*"
+          },
+          {
+            "referenceCategory": "SECURITY",
+            "referenceType": "cpe23Type",
+            "referenceLocator": "cpe:2.3:a:sagikazarmark:slog_shim:v0.1.0:*:*:*:*:*:*:*"
+          },
+          {
+            "referenceCategory": "PACKAGE-MANAGER",
+            "referenceType": "purl",
+            "referenceLocator": "pkg:golang/github.com/sagikazarmark/slog-shim@v0.1.0"
+          }
+        ]
+      },
+      {
+        "name": "github.com/sergi/go-diff",
+        "SPDXID": "SPDXRef-Package-go-module-github.com-sergi-go-diff-5f316aebeecf261b",
+        "versionInfo": "v1.3.2-0.20230802210424-5b0b94c5c0d3",
+        "supplier": "NOASSERTION",
+        "downloadLocation": "NOASSERTION",
+        "filesAnalyzed": false,
+        "checksums": [
+          {
+            "algorithm": "SHA256",
+            "checksumValue": "9faeb576bc9c385b8f2c237751cf2c07a07fb3a678b76c6f06053586d487baaf"
+          }
+        ],
+        "sourceInfo": "acquired package info from go module information: bomctl",
+        "licenseConcluded": "NOASSERTION",
+        "licenseDeclared": "NOASSERTION",
+        "copyrightText": "NOASSERTION",
+        "externalRefs": [
+          {
+            "referenceCategory": "SECURITY",
+            "referenceType": "cpe23Type",
+            "referenceLocator": "cpe:2.3:a:sergi:go-diff:v1.3.2-0.20230802210424-5b0b94c5c0d3:*:*:*:*:*:*:*"
+          },
+          {
+            "referenceCategory": "SECURITY",
+            "referenceType": "cpe23Type",
+            "referenceLocator": "cpe:2.3:a:sergi:go_diff:v1.3.2-0.20230802210424-5b0b94c5c0d3:*:*:*:*:*:*:*"
+          },
+          {
+            "referenceCategory": "PACKAGE-MANAGER",
+            "referenceType": "purl",
+            "referenceLocator": "pkg:golang/github.com/sergi/go-diff@v1.3.2-0.20230802210424-5b0b94c5c0d3"
+          }
+        ]
+      },
+      {
+        "name": "github.com/sirupsen/logrus",
+        "SPDXID": "SPDXRef-Package-go-module-github.com-sirupsen-logrus-c9d8b46f2f6f848a",
+        "versionInfo": "v1.9.3",
+        "supplier": "NOASSERTION",
+        "downloadLocation": "NOASSERTION",
+        "filesAnalyzed": false,
+        "checksums": [
+          {
+            "algorithm": "SHA256",
+            "checksumValue": "76e794409d42daaf6813717bc2f992180695b539948b345ebba7e337cbaacdb4"
+          }
+        ],
+        "sourceInfo": "acquired package info from go module information: bomctl",
+        "licenseConcluded": "NOASSERTION",
+        "licenseDeclared": "NOASSERTION",
+        "copyrightText": "NOASSERTION",
+        "externalRefs": [
+          {
+            "referenceCategory": "SECURITY",
+            "referenceType": "cpe23Type",
+            "referenceLocator": "cpe:2.3:a:sirupsen:logrus:v1.9.3:*:*:*:*:*:*:*"
+          },
+          {
+            "referenceCategory": "PACKAGE-MANAGER",
+            "referenceType": "purl",
+            "referenceLocator": "pkg:golang/github.com/sirupsen/logrus@v1.9.3"
+          }
+        ]
+      },
+      {
+        "name": "github.com/skeema/knownhosts",
+        "SPDXID": "SPDXRef-Package-go-module-github.com-skeema-knownhosts-8c3e08a98640688c",
+        "versionInfo": "v1.2.2",
+        "supplier": "NOASSERTION",
+        "downloadLocation": "NOASSERTION",
+        "filesAnalyzed": false,
+        "checksums": [
+          {
+            "algorithm": "SHA256",
+            "checksumValue": "22e8363f87cb983c3d7f8d4f07ab61c5490d5242730798bed7f7b16a3e342f70"
+          }
+        ],
+        "sourceInfo": "acquired package info from go module information: bomctl",
+        "licenseConcluded": "NOASSERTION",
+        "licenseDeclared": "NOASSERTION",
+        "copyrightText": "NOASSERTION",
+        "externalRefs": [
+          {
+            "referenceCategory": "SECURITY",
+            "referenceType": "cpe23Type",
+            "referenceLocator": "cpe:2.3:a:skeema:knownhosts:v1.2.2:*:*:*:*:*:*:*"
+          },
+          {
+            "referenceCategory": "PACKAGE-MANAGER",
+            "referenceType": "purl",
+            "referenceLocator": "pkg:golang/github.com/skeema/knownhosts@v1.2.2"
+          }
+        ]
+      },
+      {
+        "name": "github.com/spdx/tools-golang",
+        "SPDXID": "SPDXRef-Package-go-module-github.com-spdx-tools-golang-4a08aad0b2bd69dc",
+        "versionInfo": "v0.5.4",
+        "supplier": "NOASSERTION",
+        "downloadLocation": "NOASSERTION",
+        "filesAnalyzed": false,
+        "checksums": [
+          {
+            "algorithm": "SHA256",
+            "checksumValue": "7d15b88b3d7a3f564252d592b45a92e9888c8272bb5a07d3154fe5aec625bea6"
+          }
+        ],
+        "sourceInfo": "acquired package info from go module information: bomctl",
+        "licenseConcluded": "NOASSERTION",
+        "licenseDeclared": "NOASSERTION",
+        "copyrightText": "NOASSERTION",
+        "externalRefs": [
+          {
+            "referenceCategory": "SECURITY",
+            "referenceType": "cpe23Type",
+            "referenceLocator": "cpe:2.3:a:spdx:tools-golang:v0.5.4:*:*:*:*:*:*:*"
+          },
+          {
+            "referenceCategory": "SECURITY",
+            "referenceType": "cpe23Type",
+            "referenceLocator": "cpe:2.3:a:spdx:tools_golang:v0.5.4:*:*:*:*:*:*:*"
+          },
+          {
+            "referenceCategory": "PACKAGE-MANAGER",
+            "referenceType": "purl",
+            "referenceLocator": "pkg:golang/github.com/spdx/tools-golang@v0.5.4"
+          }
+        ]
+      },
+      {
+        "name": "github.com/spf13/afero",
+        "SPDXID": "SPDXRef-Package-go-module-github.com-spf13-afero-5ec6bf38d7bbe47e",
+        "versionInfo": "v1.11.0",
+        "supplier": "NOASSERTION",
+        "downloadLocation": "NOASSERTION",
+        "filesAnalyzed": false,
+        "checksums": [
+          {
+            "algorithm": "SHA256",
+            "checksumValue": "58940a86da5d9b7bf6233a86f1532aaebe917f7518a44176dfd272f7035ea4cf"
+          }
+        ],
+        "sourceInfo": "acquired package info from go module information: bomctl",
+        "licenseConcluded": "NOASSERTION",
+        "licenseDeclared": "NOASSERTION",
+        "copyrightText": "NOASSERTION",
+        "externalRefs": [
+          {
+            "referenceCategory": "SECURITY",
+            "referenceType": "cpe23Type",
+            "referenceLocator": "cpe:2.3:a:spf13:afero:v1.11.0:*:*:*:*:*:*:*"
+          },
+          {
+            "referenceCategory": "PACKAGE-MANAGER",
+            "referenceType": "purl",
+            "referenceLocator": "pkg:golang/github.com/spf13/afero@v1.11.0"
+          }
+        ]
+      },
+      {
+        "name": "github.com/spf13/cast",
+        "SPDXID": "SPDXRef-Package-go-module-github.com-spf13-cast-f6387b9a391d383c",
+        "versionInfo": "v1.6.0",
+        "supplier": "NOASSERTION",
+        "downloadLocation": "NOASSERTION",
+        "filesAnalyzed": false,
+        "checksums": [
+          {
+            "algorithm": "SHA256",
+            "checksumValue": "1848931c42c5faf691e5d873dd5a997c54b366361b81e283a41c50552e06609d"
+          }
+        ],
+        "sourceInfo": "acquired package info from go module information: bomctl",
+        "licenseConcluded": "NOASSERTION",
+        "licenseDeclared": "NOASSERTION",
+        "copyrightText": "NOASSERTION",
+        "externalRefs": [
+          {
+            "referenceCategory": "SECURITY",
+            "referenceType": "cpe23Type",
+            "referenceLocator": "cpe:2.3:a:spf13:cast:v1.6.0:*:*:*:*:*:*:*"
+          },
+          {
+            "referenceCategory": "PACKAGE-MANAGER",
+            "referenceType": "purl",
+            "referenceLocator": "pkg:golang/github.com/spf13/cast@v1.6.0"
+          }
+        ]
+      },
+      {
+        "name": "github.com/spf13/cobra",
+        "SPDXID": "SPDXRef-Package-go-module-github.com-spf13-cobra-abc1a0131d6432f9",
+        "versionInfo": "v1.8.1",
+        "supplier": "NOASSERTION",
+        "downloadLocation": "NOASSERTION",
+        "filesAnalyzed": false,
+        "checksums": [
+          {
+            "algorithm": "SHA256",
+            "checksumValue": "7b9fefc4a77fad9b1f4893145f56a0b637930dffaabf5fc974117c820e64f593"
+          }
+        ],
+        "sourceInfo": "acquired package info from go module information: bomctl",
+        "licenseConcluded": "NOASSERTION",
+        "licenseDeclared": "NOASSERTION",
+        "copyrightText": "NOASSERTION",
+        "externalRefs": [
+          {
+            "referenceCategory": "SECURITY",
+            "referenceType": "cpe23Type",
+            "referenceLocator": "cpe:2.3:a:spf13:cobra:v1.8.1:*:*:*:*:*:*:*"
+          },
+          {
+            "referenceCategory": "PACKAGE-MANAGER",
+            "referenceType": "purl",
+            "referenceLocator": "pkg:golang/github.com/spf13/cobra@v1.8.1"
+          }
+        ]
+      },
+      {
+        "name": "github.com/spf13/pflag",
+        "SPDXID": "SPDXRef-Package-go-module-github.com-spf13-pflag-0d74e9b919123713",
+        "versionInfo": "v1.0.5",
+        "supplier": "NOASSERTION",
+        "downloadLocation": "NOASSERTION",
+        "filesAnalyzed": false,
+        "checksums": [
+          {
+            "algorithm": "SHA256",
+            "checksumValue": "8b2f951543823f56bef3216da3f76b836089e6ed3246807b7d9c370cabff2570"
+          }
+        ],
+        "sourceInfo": "acquired package info from go module information: bomctl",
+        "licenseConcluded": "NOASSERTION",
+        "licenseDeclared": "NOASSERTION",
+        "copyrightText": "NOASSERTION",
+        "externalRefs": [
+          {
+            "referenceCategory": "SECURITY",
+            "referenceType": "cpe23Type",
+            "referenceLocator": "cpe:2.3:a:spf13:pflag:v1.0.5:*:*:*:*:*:*:*"
+          },
+          {
+            "referenceCategory": "PACKAGE-MANAGER",
+            "referenceType": "purl",
+            "referenceLocator": "pkg:golang/github.com/spf13/pflag@v1.0.5"
+          }
+        ]
+      },
+      {
+        "name": "github.com/spf13/viper",
+        "SPDXID": "SPDXRef-Package-go-module-github.com-spf13-viper-ee2f520636d42a46",
+        "versionInfo": "v1.19.0",
+        "supplier": "NOASSERTION",
+        "downloadLocation": "NOASSERTION",
+        "filesAnalyzed": false,
+        "checksums": [
+          {
+            "algorithm": "SHA256",
+            "checksumValue": "456ab94848edf28db94913b2377cf63ab0c1f65ed13ddde5c13594f0470475c2"
+          }
+        ],
+        "sourceInfo": "acquired package info from go module information: bomctl",
+        "licenseConcluded": "NOASSERTION",
+        "licenseDeclared": "NOASSERTION",
+        "copyrightText": "NOASSERTION",
+        "externalRefs": [
+          {
+            "referenceCategory": "SECURITY",
+            "referenceType": "cpe23Type",
+            "referenceLocator": "cpe:2.3:a:spf13:viper:v1.19.0:*:*:*:*:*:*:*"
+          },
+          {
+            "referenceCategory": "PACKAGE-MANAGER",
+            "referenceType": "purl",
+            "referenceLocator": "pkg:golang/github.com/spf13/viper@v1.19.0"
+          }
+        ]
+      },
+      {
+        "name": "github.com/subosito/gotenv",
+        "SPDXID": "SPDXRef-Package-go-module-github.com-subosito-gotenv-fcb83a5920e185c4",
+        "versionInfo": "v1.6.0",
+        "supplier": "NOASSERTION",
+        "downloadLocation": "NOASSERTION",
+        "filesAnalyzed": false,
+        "checksums": [
+          {
+            "algorithm": "SHA256",
+            "checksumValue": "f4d9530dcd454ece2abb40c3abb004b533cdc3a4959bbb8132c50252300121ff"
+          }
+        ],
+        "sourceInfo": "acquired package info from go module information: bomctl",
+        "licenseConcluded": "NOASSERTION",
+        "licenseDeclared": "NOASSERTION",
+        "copyrightText": "NOASSERTION",
+        "externalRefs": [
+          {
+            "referenceCategory": "SECURITY",
+            "referenceType": "cpe23Type",
+            "referenceLocator": "cpe:2.3:a:subosito:gotenv:v1.6.0:*:*:*:*:*:*:*"
+          },
+          {
+            "referenceCategory": "PACKAGE-MANAGER",
+            "referenceType": "purl",
+            "referenceLocator": "pkg:golang/github.com/subosito/gotenv@v1.6.0"
+          }
+        ]
+      },
+      {
+        "name": "github.com/xanzy/ssh-agent",
+        "SPDXID": "SPDXRef-Package-go-module-github.com-xanzy-ssh-agent-fc817718385f3705",
+        "versionInfo": "v0.3.3",
+        "supplier": "NOASSERTION",
+        "downloadLocation": "NOASSERTION",
+        "filesAnalyzed": false,
+        "checksums": [
+          {
+            "algorithm": "SHA256",
+            "checksumValue": "fbfd79a497e0fd1b13c6a61c5fa7c7a8e5d9c3030ffb657261625e58cdaa4053"
+          }
+        ],
+        "sourceInfo": "acquired package info from go module information: bomctl",
+        "licenseConcluded": "NOASSERTION",
+        "licenseDeclared": "NOASSERTION",
+        "copyrightText": "NOASSERTION",
+        "externalRefs": [
+          {
+            "referenceCategory": "SECURITY",
+            "referenceType": "cpe23Type",
+            "referenceLocator": "cpe:2.3:a:xanzy:ssh-agent:v0.3.3:*:*:*:*:*:*:*"
+          },
+          {
+            "referenceCategory": "SECURITY",
+            "referenceType": "cpe23Type",
+            "referenceLocator": "cpe:2.3:a:xanzy:ssh_agent:v0.3.3:*:*:*:*:*:*:*"
+          },
+          {
+            "referenceCategory": "PACKAGE-MANAGER",
+            "referenceType": "purl",
+            "referenceLocator": "pkg:golang/github.com/xanzy/ssh-agent@v0.3.3"
+          }
+        ]
+      },
+      {
+        "name": "github.com/zclconf/go-cty",
+        "SPDXID": "SPDXRef-Package-go-module-github.com-zclconf-go-cty-5003adc9dafdd21d",
+        "versionInfo": "v1.8.0",
+        "supplier": "NOASSERTION",
+        "downloadLocation": "NOASSERTION",
+        "filesAnalyzed": false,
+        "checksums": [
+          {
+            "algorithm": "SHA256",
+            "checksumValue": "b3802fa9a790cc922ede776fe205488699550f492b53e6e0adc2d25549da5ae0"
+          }
+        ],
+        "sourceInfo": "acquired package info from go module information: bomctl",
+        "licenseConcluded": "NOASSERTION",
+        "licenseDeclared": "NOASSERTION",
+        "copyrightText": "NOASSERTION",
+        "externalRefs": [
+          {
+            "referenceCategory": "SECURITY",
+            "referenceType": "cpe23Type",
+            "referenceLocator": "cpe:2.3:a:zclconf:go-cty:v1.8.0:*:*:*:*:*:*:*"
+          },
+          {
+            "referenceCategory": "SECURITY",
+            "referenceType": "cpe23Type",
+            "referenceLocator": "cpe:2.3:a:zclconf:go_cty:v1.8.0:*:*:*:*:*:*:*"
+          },
+          {
+            "referenceCategory": "PACKAGE-MANAGER",
+            "referenceType": "purl",
+            "referenceLocator": "pkg:golang/github.com/zclconf/go-cty@v1.8.0"
+          }
+        ]
+      },
+      {
+        "name": "golang.org/x/crypto",
+        "SPDXID": "SPDXRef-Package-go-module-golang.org-x-crypto-cad8ee1f69d6ff20",
+        "versionInfo": "v0.23.0",
+        "supplier": "NOASSERTION",
+        "downloadLocation": "NOASSERTION",
+        "filesAnalyzed": false,
+        "checksums": [
+          {
+            "algorithm": "SHA256",
+            "checksumValue": "748254fefd89f0c760963ffcac9e9450e33765cf732d9c55670c31328a144802"
+          }
+        ],
+        "sourceInfo": "acquired package info from go module information: bomctl",
+        "licenseConcluded": "NOASSERTION",
+        "licenseDeclared": "NOASSERTION",
+        "copyrightText": "NOASSERTION",
+        "externalRefs": [
+          {
+            "referenceCategory": "SECURITY",
+            "referenceType": "cpe23Type",
+            "referenceLocator": "cpe:2.3:a:golang:x\\/crypto:v0.23.0:*:*:*:*:*:*:*"
+          },
+          {
+            "referenceCategory": "PACKAGE-MANAGER",
+            "referenceType": "purl",
+            "referenceLocator": "pkg:golang/golang.org/x/crypto@v0.23.0"
+          }
+        ]
+      },
+      {
+        "name": "golang.org/x/mod",
+        "SPDXID": "SPDXRef-Package-go-module-golang.org-x-mod-2ff257ab3ed63de6",
+        "versionInfo": "v0.17.0",
+        "supplier": "NOASSERTION",
+        "downloadLocation": "NOASSERTION",
+        "filesAnalyzed": false,
+        "checksums": [
+          {
+            "algorithm": "SHA256",
+            "checksumValue": "cd8e78526be2a4788d77ea66fa6d31f4a859f61975ffb40d332c576dce880aa0"
+          }
+        ],
+        "sourceInfo": "acquired package info from go module information: bomctl",
+        "licenseConcluded": "NOASSERTION",
+        "licenseDeclared": "NOASSERTION",
+        "copyrightText": "NOASSERTION",
+        "externalRefs": [
+          {
+            "referenceCategory": "SECURITY",
+            "referenceType": "cpe23Type",
+            "referenceLocator": "cpe:2.3:a:golang:x\\/mod:v0.17.0:*:*:*:*:*:*:*"
+          },
+          {
+            "referenceCategory": "PACKAGE-MANAGER",
+            "referenceType": "purl",
+            "referenceLocator": "pkg:golang/golang.org/x/mod@v0.17.0"
+          }
+        ]
+      },
+      {
+        "name": "golang.org/x/net",
+        "SPDXID": "SPDXRef-Package-go-module-golang.org-x-net-61049d6178cf00bc",
+        "versionInfo": "v0.25.0",
+        "supplier": "NOASSERTION",
+        "downloadLocation": "NOASSERTION",
+        "filesAnalyzed": false,
+        "checksums": [
+          {
+            "algorithm": "SHA256",
+            "checksumValue": "77f3820a804452adf7a63c9d2ab190870ec89543c8d8eca5afef2a2f1e3d91a7"
+          }
+        ],
+        "sourceInfo": "acquired package info from go module information: bomctl",
+        "licenseConcluded": "NOASSERTION",
+        "licenseDeclared": "NOASSERTION",
+        "copyrightText": "NOASSERTION",
+        "externalRefs": [
+          {
+            "referenceCategory": "SECURITY",
+            "referenceType": "cpe23Type",
+            "referenceLocator": "cpe:2.3:a:golang:networking:v0.25.0:*:*:*:*:go:*:*"
+          },
+          {
+            "referenceCategory": "PACKAGE-MANAGER",
+            "referenceType": "purl",
+            "referenceLocator": "pkg:golang/golang.org/x/net@v0.25.0"
+          }
+        ]
+      },
+      {
+        "name": "golang.org/x/sync",
+        "SPDXID": "SPDXRef-Package-go-module-golang.org-x-sync-f3affac3cfb945cc",
+        "versionInfo": "v0.7.0",
+        "supplier": "NOASSERTION",
+        "downloadLocation": "NOASSERTION",
+        "filesAnalyzed": false,
+        "checksums": [
+          {
+            "algorithm": "SHA256",
+            "checksumValue": "62c2267d20683fd40f60bd31c8a24fab481c689746deb227a2ac5359b7d0bbd3"
+          }
+        ],
+        "sourceInfo": "acquired package info from go module information: bomctl",
+        "licenseConcluded": "NOASSERTION",
+        "licenseDeclared": "NOASSERTION",
+        "copyrightText": "NOASSERTION",
+        "externalRefs": [
+          {
+            "referenceCategory": "SECURITY",
+            "referenceType": "cpe23Type",
+            "referenceLocator": "cpe:2.3:a:golang:x\\/sync:v0.7.0:*:*:*:*:*:*:*"
+          },
+          {
+            "referenceCategory": "PACKAGE-MANAGER",
+            "referenceType": "purl",
+            "referenceLocator": "pkg:golang/golang.org/x/sync@v0.7.0"
+          }
+        ]
+      },
+      {
+        "name": "golang.org/x/sys",
+        "SPDXID": "SPDXRef-Package-go-module-golang.org-x-sys-d48df6a309bf0b5a",
+        "versionInfo": "v0.21.0",
+        "supplier": "NOASSERTION",
+        "downloadLocation": "NOASSERTION",
+        "filesAnalyzed": false,
+        "checksums": [
+          {
+            "algorithm": "SHA256",
+            "checksumValue": "ac5fa9633dc300649003102ed426c2edc6ad660e1e6c2e1421e2212b1059bf0b"
+          }
+        ],
+        "sourceInfo": "acquired package info from go module information: bomctl",
+        "licenseConcluded": "NOASSERTION",
+        "licenseDeclared": "NOASSERTION",
+        "copyrightText": "NOASSERTION",
+        "externalRefs": [
+          {
+            "referenceCategory": "SECURITY",
+            "referenceType": "cpe23Type",
+            "referenceLocator": "cpe:2.3:a:golang:x\\/sys:v0.21.0:*:*:*:*:*:*:*"
+          },
+          {
+            "referenceCategory": "PACKAGE-MANAGER",
+            "referenceType": "purl",
+            "referenceLocator": "pkg:golang/golang.org/x/sys@v0.21.0"
+          }
+        ]
+      },
+      {
+        "name": "golang.org/x/text",
+        "SPDXID": "SPDXRef-Package-go-module-golang.org-x-text-0a267aadea95f8bc",
+        "versionInfo": "v0.15.0",
+        "supplier": "NOASSERTION",
+        "downloadLocation": "NOASSERTION",
+        "filesAnalyzed": false,
+        "checksums": [
+          {
+            "algorithm": "SHA256",
+            "checksumValue": "87557fe208c1bfcbfd723711ebe011e7efdc2182b937f580822bf8c65b04b409"
+          }
+        ],
+        "sourceInfo": "acquired package info from go module information: bomctl",
+        "licenseConcluded": "NOASSERTION",
+        "licenseDeclared": "NOASSERTION",
+        "copyrightText": "NOASSERTION",
+        "externalRefs": [
+          {
+            "referenceCategory": "SECURITY",
+            "referenceType": "cpe23Type",
+            "referenceLocator": "cpe:2.3:a:golang:text:v0.15.0:*:*:*:*:*:*:*"
+          },
+          {
+            "referenceCategory": "PACKAGE-MANAGER",
+            "referenceType": "purl",
+            "referenceLocator": "pkg:golang/golang.org/x/text@v0.15.0"
+          }
+        ]
+      },
+      {
+        "name": "google.golang.org/protobuf",
+        "SPDXID": "SPDXRef-Package-go-module-google.golang.org-protobuf-d430c7a0e4539ea4",
+        "versionInfo": "v1.34.1",
+        "supplier": "NOASSERTION",
+        "downloadLocation": "NOASSERTION",
+        "filesAnalyzed": false,
+        "checksums": [
+          {
+            "algorithm": "SHA256",
+            "checksumValue": "f5d7500637c2c993ce1cf5223f1a5811204b73e4fc3f713e568e086ca6601568"
+          }
+        ],
+        "sourceInfo": "acquired package info from go module information: bomctl",
+        "licenseConcluded": "NOASSERTION",
+        "licenseDeclared": "NOASSERTION",
+        "copyrightText": "NOASSERTION",
+        "externalRefs": [
+          {
+            "referenceCategory": "SECURITY",
+            "referenceType": "cpe23Type",
+            "referenceLocator": "cpe:2.3:a:google:protobuf:v1.34.1:*:*:*:*:*:*:*"
+          },
+          {
+            "referenceCategory": "PACKAGE-MANAGER",
+            "referenceType": "purl",
+            "referenceLocator": "pkg:golang/google.golang.org/protobuf@v1.34.1"
+          }
+        ]
+      },
+      {
+        "name": "gopkg.in/ini.v1",
+        "SPDXID": "SPDXRef-Package-go-module-gopkg.in-ini.v1-d4dcf7d18233628d",
+        "versionInfo": "v1.67.0",
+        "supplier": "NOASSERTION",
+        "downloadLocation": "NOASSERTION",
+        "filesAnalyzed": false,
+        "checksums": [
+          {
+            "algorithm": "SHA256",
+            "checksumValue": "0e09f1fbafa77c4f887f38d410848d7b274f261f405cd36c59b18ff4acc2b0e0"
+          }
+        ],
+        "sourceInfo": "acquired package info from go module information: bomctl",
+        "licenseConcluded": "NOASSERTION",
+        "licenseDeclared": "NOASSERTION",
+        "copyrightText": "NOASSERTION",
+        "externalRefs": [
+          {
+            "referenceCategory": "PACKAGE-MANAGER",
+            "referenceType": "purl",
+            "referenceLocator": "pkg:golang/gopkg.in/ini.v1@v1.67.0"
+          }
+        ]
+      },
+      {
+        "name": "gopkg.in/warnings.v0",
+        "SPDXID": "SPDXRef-Package-go-module-gopkg.in-warnings.v0-3054011fb8872ecd",
+        "versionInfo": "v0.1.2",
+        "supplier": "NOASSERTION",
+        "downloadLocation": "NOASSERTION",
+        "filesAnalyzed": false,
+        "checksums": [
+          {
+            "algorithm": "SHA256",
+            "checksumValue": "c055d56c563c0d8e7fc4e7b510289674a0b3665c60b2171854d9011ecb4044c1"
+          }
+        ],
+        "sourceInfo": "acquired package info from go module information: bomctl",
+        "licenseConcluded": "NOASSERTION",
+        "licenseDeclared": "NOASSERTION",
+        "copyrightText": "NOASSERTION",
+        "externalRefs": [
+          {
+            "referenceCategory": "PACKAGE-MANAGER",
+            "referenceType": "purl",
+            "referenceLocator": "pkg:golang/gopkg.in/warnings.v0@v0.1.2"
+          }
+        ]
+      },
+      {
+        "name": "gopkg.in/yaml.v3",
+        "SPDXID": "SPDXRef-Package-go-module-gopkg.in-yaml.v3-cb259ab751a0f22e",
+        "versionInfo": "v3.0.1",
+        "supplier": "NOASSERTION",
+        "downloadLocation": "NOASSERTION",
+        "filesAnalyzed": false,
+        "checksums": [
+          {
+            "algorithm": "SHA256",
+            "checksumValue": "7f1566fc6cc0cc45aa2c7baf72d23dd4a4bd8613669963a85aed174d8252ec20"
+          }
+        ],
+        "sourceInfo": "acquired package info from go module information: bomctl",
+        "licenseConcluded": "NOASSERTION",
+        "licenseDeclared": "NOASSERTION",
+        "copyrightText": "NOASSERTION",
+        "externalRefs": [
+          {
+            "referenceCategory": "SECURITY",
+            "referenceType": "cpe23Type",
+            "referenceLocator": "cpe:2.3:a:yaml_project:yaml:v3.0.1:*:*:*:*:go:*:*"
+          },
+          {
+            "referenceCategory": "PACKAGE-MANAGER",
+            "referenceType": "purl",
+            "referenceLocator": "pkg:golang/gopkg.in/yaml.v3@v3.0.1"
+          }
+        ]
+      },
+      {
+        "name": "modernc.org/libc",
+        "SPDXID": "SPDXRef-Package-go-module-modernc.org-libc-b7512b701a20d0b3",
+        "versionInfo": "v1.40.6",
+        "supplier": "NOASSERTION",
+        "downloadLocation": "NOASSERTION",
+        "filesAnalyzed": false,
+        "checksums": [
+          {
+            "algorithm": "SHA256",
+            "checksumValue": "d78d491eadd28e138e0a31020600f82bc5604c53b2d7d0a71f0ae80b4f030228"
+          }
+        ],
+        "sourceInfo": "acquired package info from go module information: bomctl",
+        "licenseConcluded": "NOASSERTION",
+        "licenseDeclared": "NOASSERTION",
+        "copyrightText": "NOASSERTION",
+        "externalRefs": [
+          {
+            "referenceCategory": "PACKAGE-MANAGER",
+            "referenceType": "purl",
+            "referenceLocator": "pkg:golang/modernc.org/libc@v1.40.6"
+          }
+        ]
+      },
+      {
+        "name": "modernc.org/mathutil",
+        "SPDXID": "SPDXRef-Package-go-module-modernc.org-mathutil-dcbd9a97ad7457a1",
+        "versionInfo": "v1.6.0",
+        "supplier": "NOASSERTION",
+        "downloadLocation": "NOASSERTION",
+        "filesAnalyzed": false,
+        "checksums": [
+          {
+            "algorithm": "SHA256",
+            "checksumValue": "7d17bdf8099895a7a3fbae09b04121a16b8060190eb5088c114ee7fd781f622e"
+          }
+        ],
+        "sourceInfo": "acquired package info from go module information: bomctl",
+        "licenseConcluded": "NOASSERTION",
+        "licenseDeclared": "NOASSERTION",
+        "copyrightText": "NOASSERTION",
+        "externalRefs": [
+          {
+            "referenceCategory": "PACKAGE-MANAGER",
+            "referenceType": "purl",
+            "referenceLocator": "pkg:golang/modernc.org/mathutil@v1.6.0"
+          }
+        ]
+      },
+      {
+        "name": "modernc.org/memory",
+        "SPDXID": "SPDXRef-Package-go-module-modernc.org-memory-66ce26f959dea890",
+        "versionInfo": "v1.7.2",
+        "supplier": "NOASSERTION",
+        "downloadLocation": "NOASSERTION",
+        "filesAnalyzed": false,
+        "checksums": [
+          {
+            "algorithm": "SHA256",
+            "checksumValue": "2a587dd12db5e66987f1cf603bdf10c5016c63e5b8e7513c027ce3a04d9e7b51"
+          }
+        ],
+        "sourceInfo": "acquired package info from go module information: bomctl",
+        "licenseConcluded": "NOASSERTION",
+        "licenseDeclared": "NOASSERTION",
+        "copyrightText": "NOASSERTION",
+        "externalRefs": [
+          {
+            "referenceCategory": "PACKAGE-MANAGER",
+            "referenceType": "purl",
+            "referenceLocator": "pkg:golang/modernc.org/memory@v1.7.2"
+          }
+        ]
+      },
+      {
+        "name": "modernc.org/sqlite",
+        "SPDXID": "SPDXRef-Package-go-module-modernc.org-sqlite-09e0d1c3ad5deb81",
+        "versionInfo": "v1.28.0",
+        "supplier": "NOASSERTION",
+        "downloadLocation": "NOASSERTION",
+        "filesAnalyzed": false,
+        "checksums": [
+          {
+            "algorithm": "SHA256",
+            "checksumValue": "671f8bc830e65dcccd9c441dbcfb847dc15503664fc9a0fb5026438de7f70474"
+          }
+        ],
+        "sourceInfo": "acquired package info from go module information: bomctl",
+        "licenseConcluded": "NOASSERTION",
+        "licenseDeclared": "NOASSERTION",
+        "copyrightText": "NOASSERTION",
+        "externalRefs": [
+          {
+            "referenceCategory": "PACKAGE-MANAGER",
+            "referenceType": "purl",
+            "referenceLocator": "pkg:golang/modernc.org/sqlite@v1.28.0"
+          }
+        ]
+      },
+      {
+        "name": "oras.land/oras-go/v2",
+        "SPDXID": "SPDXRef-Package-go-module-oras.land-oras-go-v2-9b2a46aa5362acff",
+        "versionInfo": "v2.5.0",
+        "supplier": "NOASSERTION",
+        "downloadLocation": "NOASSERTION",
+        "filesAnalyzed": false,
+        "checksums": [
+          {
+            "algorithm": "SHA256",
+            "checksumValue": "a3c31ef642d8ef8569e6ec34ed05cf8a2b63b30eea3578bc4f077ed7d65fd367"
+          }
+        ],
+        "sourceInfo": "acquired package info from go module information: bomctl",
+        "licenseConcluded": "NOASSERTION",
+        "licenseDeclared": "NOASSERTION",
+        "copyrightText": "NOASSERTION",
+        "externalRefs": [
+          {
+            "referenceCategory": "SECURITY",
+            "referenceType": "cpe23Type",
+            "referenceLocator": "cpe:2.3:a:oras-go:v2:v2.5.0:*:*:*:*:*:*:*"
+          },
+          {
+            "referenceCategory": "SECURITY",
+            "referenceType": "cpe23Type",
+            "referenceLocator": "cpe:2.3:a:oras_go:v2:v2.5.0:*:*:*:*:*:*:*"
+          },
+          {
+            "referenceCategory": "SECURITY",
+            "referenceType": "cpe23Type",
+            "referenceLocator": "cpe:2.3:a:oras:v2:v2.5.0:*:*:*:*:*:*:*"
+          },
+          {
+            "referenceCategory": "PACKAGE-MANAGER",
+            "referenceType": "purl",
+            "referenceLocator": "pkg:golang/oras.land/oras-go/v2@v2.5.0"
+          }
+        ]
+      },
+      {
+        "name": "sigs.k8s.io/release-utils",
+        "SPDXID": "SPDXRef-Package-go-module-sigs.k8s.io-release-utils-2930a4d6baa94c8d",
+        "versionInfo": "v0.8.2",
+        "supplier": "NOASSERTION",
+        "downloadLocation": "NOASSERTION",
+        "filesAnalyzed": false,
+        "checksums": [
+          {
+            "algorithm": "SHA256",
+            "checksumValue": "04a08a69bb15931cbfad345d3de1f6b7fbf635253cb4cb747d82166f2de1c4a4"
+          }
+        ],
+        "sourceInfo": "acquired package info from go module information: bomctl",
+        "licenseConcluded": "NOASSERTION",
+        "licenseDeclared": "NOASSERTION",
+        "copyrightText": "NOASSERTION",
+        "externalRefs": [
+          {
+            "referenceCategory": "PACKAGE-MANAGER",
+            "referenceType": "purl",
+            "referenceLocator": "pkg:golang/sigs.k8s.io/release-utils@v0.8.2"
+          }
+        ]
+      },
+      {
+        "name": "stdlib",
+        "SPDXID": "SPDXRef-Package-go-module-stdlib-f9d1785bc3385da5",
+        "versionInfo": "go1.22.0",
+        "supplier": "NOASSERTION",
+        "downloadLocation": "NOASSERTION",
+        "filesAnalyzed": false,
+        "sourceInfo": "acquired package info from go module information: bomctl",
+        "licenseConcluded": "NOASSERTION",
+        "licenseDeclared": "BSD-3-Clause",
+        "copyrightText": "NOASSERTION",
+        "externalRefs": [
+          {
+            "referenceCategory": "SECURITY",
+            "referenceType": "cpe23Type",
+            "referenceLocator": "cpe:2.3:a:golang:go:1.22.0:-:*:*:*:*:*:*"
+          },
+          {
+            "referenceCategory": "PACKAGE-MANAGER",
+            "referenceType": "purl",
+            "referenceLocator": "pkg:golang/stdlib@1.22.0"
+          }
+        ]
+      },
+      {
+        "name": "bomctl_0.3.0_darwin_arm64.tar.gz",
+        "SPDXID": "SPDXRef-DocumentRoot-File-bomctl-0.3.0-darwin-arm64.tar.gz",
+        "versionInfo": "sha256:0685b866d6a7a0175e92a17cbbe0fb344f3ffdd108009317b64dd15c611bb6bc",
+        "supplier": "NOASSERTION",
+        "downloadLocation": "NOASSERTION",
+        "filesAnalyzed": false,
+        "checksums": [
+          {
+            "algorithm": "SHA256",
+            "checksumValue": "0685b866d6a7a0175e92a17cbbe0fb344f3ffdd108009317b64dd15c611bb6bc"
+          }
+        ],
+        "licenseConcluded": "NOASSERTION",
+        "licenseDeclared": "NOASSERTION",
+        "primaryPackagePurpose": "FILE"
+      }
+    ],
+    "files": [
+      {
+        "fileName": "bomctl",
+        "SPDXID": "SPDXRef-File-bomctl-71fa836d87ca4748",
+        "checksums": [
+          {
+            "algorithm": "SHA1",
+            "checksumValue": "0000000000000000000000000000000000000000"
+          }
+        ],
+        "licenseConcluded": "NOASSERTION",
+        "licenseInfoInFiles": [
+          "NOASSERTION"
+        ],
+        "copyrightText": ""
+      }
+    ],
+    "relationships": [
+      {
+        "spdxElementId": "SPDXRef-Package-go-module-github.com-go-openapi-inflect-04ffedb8f70e9170",
+        "relatedSpdxElement": "SPDXRef-File-bomctl-71fa836d87ca4748",
+        "relationshipType": "OTHER",
+        "comment": "evident-by: indicates the package's existence is evident by the given file"
+      },
+      {
+        "spdxElementId": "SPDXRef-Package-go-module-github.com-go-openapi-inflect-04ffedb8f70e9170",
+        "relatedSpdxElement": "SPDXRef-Package-go-module-github.com-bomctl-bomctl-d3de1d7b912744e1",
+        "relationshipType": "DEPENDENCY_OF"
+      },
+      {
+        "spdxElementId": "SPDXRef-Package-go-module-modernc.org-sqlite-09e0d1c3ad5deb81",
+        "relatedSpdxElement": "SPDXRef-File-bomctl-71fa836d87ca4748",
+        "relationshipType": "OTHER",
+        "comment": "evident-by: indicates the package's existence is evident by the given file"
+      },
+      {
+        "spdxElementId": "SPDXRef-Package-go-module-modernc.org-sqlite-09e0d1c3ad5deb81",
+        "relatedSpdxElement": "SPDXRef-Package-go-module-github.com-bomctl-bomctl-d3de1d7b912744e1",
+        "relationshipType": "DEPENDENCY_OF"
+      },
+      {
+        "spdxElementId": "SPDXRef-Package-go-module-golang.org-x-text-0a267aadea95f8bc",
+        "relatedSpdxElement": "SPDXRef-File-bomctl-71fa836d87ca4748",
+        "relationshipType": "OTHER",
+        "comment": "evident-by: indicates the package's existence is evident by the given file"
+      },
+      {
+        "spdxElementId": "SPDXRef-Package-go-module-golang.org-x-text-0a267aadea95f8bc",
+        "relatedSpdxElement": "SPDXRef-Package-go-module-github.com-bomctl-bomctl-d3de1d7b912744e1",
+        "relationshipType": "DEPENDENCY_OF"
+      },
+      {
+        "spdxElementId": "SPDXRef-Package-go-module-github.com-pelletier-go-toml-v2-0c4beda42b47b30f",
+        "relatedSpdxElement": "SPDXRef-File-bomctl-71fa836d87ca4748",
+        "relationshipType": "OTHER",
+        "comment": "evident-by: indicates the package's existence is evident by the given file"
+      },
+      {
+        "spdxElementId": "SPDXRef-Package-go-module-github.com-pelletier-go-toml-v2-0c4beda42b47b30f",
+        "relatedSpdxElement": "SPDXRef-Package-go-module-github.com-bomctl-bomctl-d3de1d7b912744e1",
+        "relationshipType": "DEPENDENCY_OF"
+      },
+      {
+        "spdxElementId": "SPDXRef-Package-go-module-github.com-spf13-pflag-0d74e9b919123713",
+        "relatedSpdxElement": "SPDXRef-File-bomctl-71fa836d87ca4748",
+        "relationshipType": "OTHER",
+        "comment": "evident-by: indicates the package's existence is evident by the given file"
+      },
+      {
+        "spdxElementId": "SPDXRef-Package-go-module-github.com-spf13-pflag-0d74e9b919123713",
+        "relatedSpdxElement": "SPDXRef-Package-go-module-github.com-bomctl-bomctl-d3de1d7b912744e1",
+        "relationshipType": "DEPENDENCY_OF"
+      },
+      {
+        "spdxElementId": "SPDXRef-Package-go-module-github.com-golang-groupcache-0dceeab7e0e706b1",
+        "relatedSpdxElement": "SPDXRef-File-bomctl-71fa836d87ca4748",
+        "relationshipType": "OTHER",
+        "comment": "evident-by: indicates the package's existence is evident by the given file"
+      },
+      {
+        "spdxElementId": "SPDXRef-Package-go-module-github.com-golang-groupcache-0dceeab7e0e706b1",
+        "relatedSpdxElement": "SPDXRef-Package-go-module-github.com-bomctl-bomctl-d3de1d7b912744e1",
+        "relationshipType": "DEPENDENCY_OF"
+      },
+      {
+        "spdxElementId": "SPDXRef-Package-go-module-github.com-ProtonMail-go-crypto-0ed0e0ef656bde63",
+        "relatedSpdxElement": "SPDXRef-File-bomctl-71fa836d87ca4748",
+        "relationshipType": "OTHER",
+        "comment": "evident-by: indicates the package's existence is evident by the given file"
+      },
+      {
+        "spdxElementId": "SPDXRef-Package-go-module-github.com-ProtonMail-go-crypto-0ed0e0ef656bde63",
+        "relatedSpdxElement": "SPDXRef-Package-go-module-github.com-bomctl-bomctl-d3de1d7b912744e1",
+        "relationshipType": "DEPENDENCY_OF"
+      },
+      {
+        "spdxElementId": "SPDXRef-Package-go-module-github.com-CycloneDX-cyclonedx-go-123d16cf974edfaa",
+        "relatedSpdxElement": "SPDXRef-File-bomctl-71fa836d87ca4748",
+        "relationshipType": "OTHER",
+        "comment": "evident-by: indicates the package's existence is evident by the given file"
+      },
+      {
+        "spdxElementId": "SPDXRef-Package-go-module-github.com-CycloneDX-cyclonedx-go-123d16cf974edfaa",
+        "relatedSpdxElement": "SPDXRef-Package-go-module-github.com-bomctl-bomctl-d3de1d7b912744e1",
+        "relationshipType": "DEPENDENCY_OF"
+      },
+      {
+        "spdxElementId": "SPDXRef-Package-go-module-github.com-apparentlymart-go-textseg-v13-1c79ce3d5e07ff7f",
+        "relatedSpdxElement": "SPDXRef-File-bomctl-71fa836d87ca4748",
+        "relationshipType": "OTHER",
+        "comment": "evident-by: indicates the package's existence is evident by the given file"
+      },
+      {
+        "spdxElementId": "SPDXRef-Package-go-module-github.com-apparentlymart-go-textseg-v13-1c79ce3d5e07ff7f",
+        "relatedSpdxElement": "SPDXRef-Package-go-module-github.com-bomctl-bomctl-d3de1d7b912744e1",
+        "relationshipType": "DEPENDENCY_OF"
+      },
+      {
+        "spdxElementId": "SPDXRef-Package-go-module-github.com-charmbracelet-log-230150632de127f8",
+        "relatedSpdxElement": "SPDXRef-File-bomctl-71fa836d87ca4748",
+        "relationshipType": "OTHER",
+        "comment": "evident-by: indicates the package's existence is evident by the given file"
+      },
+      {
+        "spdxElementId": "SPDXRef-Package-go-module-github.com-charmbracelet-log-230150632de127f8",
+        "relatedSpdxElement": "SPDXRef-Package-go-module-github.com-bomctl-bomctl-d3de1d7b912744e1",
+        "relationshipType": "DEPENDENCY_OF"
+      },
+      {
+        "spdxElementId": "SPDXRef-Package-go-module-github.com-jbenet-go-context-27b65da1f0dfe16d",
+        "relatedSpdxElement": "SPDXRef-File-bomctl-71fa836d87ca4748",
+        "relationshipType": "OTHER",
+        "comment": "evident-by: indicates the package's existence is evident by the given file"
+      },
+      {
+        "spdxElementId": "SPDXRef-Package-go-module-github.com-jbenet-go-context-27b65da1f0dfe16d",
+        "relatedSpdxElement": "SPDXRef-Package-go-module-github.com-bomctl-bomctl-d3de1d7b912744e1",
+        "relationshipType": "DEPENDENCY_OF"
+      },
+      {
+        "spdxElementId": "SPDXRef-Package-go-module-github.com-go-logfmt-logfmt-28cc7b512b5b0b8a",
+        "relatedSpdxElement": "SPDXRef-File-bomctl-71fa836d87ca4748",
+        "relationshipType": "OTHER",
+        "comment": "evident-by: indicates the package's existence is evident by the given file"
+      },
+      {
+        "spdxElementId": "SPDXRef-Package-go-module-github.com-go-logfmt-logfmt-28cc7b512b5b0b8a",
+        "relatedSpdxElement": "SPDXRef-Package-go-module-github.com-bomctl-bomctl-d3de1d7b912744e1",
+        "relationshipType": "DEPENDENCY_OF"
+      },
+      {
+        "spdxElementId": "SPDXRef-Package-go-module-sigs.k8s.io-release-utils-2930a4d6baa94c8d",
+        "relatedSpdxElement": "SPDXRef-File-bomctl-71fa836d87ca4748",
+        "relationshipType": "OTHER",
+        "comment": "evident-by: indicates the package's existence is evident by the given file"
+      },
+      {
+        "spdxElementId": "SPDXRef-Package-go-module-sigs.k8s.io-release-utils-2930a4d6baa94c8d",
+        "relatedSpdxElement": "SPDXRef-Package-go-module-github.com-bomctl-bomctl-d3de1d7b912744e1",
+        "relationshipType": "DEPENDENCY_OF"
+      },
+      {
+        "spdxElementId": "SPDXRef-Package-go-module-entgo.io-ent-2f326bd8f7351e93",
+        "relatedSpdxElement": "SPDXRef-File-bomctl-71fa836d87ca4748",
+        "relationshipType": "OTHER",
+        "comment": "evident-by: indicates the package's existence is evident by the given file"
+      },
+      {
+        "spdxElementId": "SPDXRef-Package-go-module-entgo.io-ent-2f326bd8f7351e93",
+        "relatedSpdxElement": "SPDXRef-Package-go-module-github.com-bomctl-bomctl-d3de1d7b912744e1",
+        "relationshipType": "DEPENDENCY_OF"
+      },
+      {
+        "spdxElementId": "SPDXRef-Package-go-module-golang.org-x-mod-2ff257ab3ed63de6",
+        "relatedSpdxElement": "SPDXRef-File-bomctl-71fa836d87ca4748",
+        "relationshipType": "OTHER",
+        "comment": "evident-by: indicates the package's existence is evident by the given file"
+      },
+      {
+        "spdxElementId": "SPDXRef-Package-go-module-golang.org-x-mod-2ff257ab3ed63de6",
+        "relatedSpdxElement": "SPDXRef-Package-go-module-github.com-bomctl-bomctl-d3de1d7b912744e1",
+        "relationshipType": "DEPENDENCY_OF"
+      },
+      {
+        "spdxElementId": "SPDXRef-Package-go-module-gopkg.in-warnings.v0-3054011fb8872ecd",
+        "relatedSpdxElement": "SPDXRef-File-bomctl-71fa836d87ca4748",
+        "relationshipType": "OTHER",
+        "comment": "evident-by: indicates the package's existence is evident by the given file"
+      },
+      {
+        "spdxElementId": "SPDXRef-Package-go-module-gopkg.in-warnings.v0-3054011fb8872ecd",
+        "relatedSpdxElement": "SPDXRef-Package-go-module-github.com-bomctl-bomctl-d3de1d7b912744e1",
+        "relationshipType": "DEPENDENCY_OF"
+      },
+      {
+        "spdxElementId": "SPDXRef-Package-go-module-github.com-charmbracelet-lipgloss-3c246a3a04019348",
+        "relatedSpdxElement": "SPDXRef-File-bomctl-71fa836d87ca4748",
+        "relationshipType": "OTHER",
+        "comment": "evident-by: indicates the package's existence is evident by the given file"
+      },
+      {
+        "spdxElementId": "SPDXRef-Package-go-module-github.com-charmbracelet-lipgloss-3c246a3a04019348",
+        "relatedSpdxElement": "SPDXRef-Package-go-module-github.com-bomctl-bomctl-d3de1d7b912744e1",
+        "relationshipType": "DEPENDENCY_OF"
+      },
+      {
+        "spdxElementId": "SPDXRef-Package-go-module-github.com-jdx-go-netrc-41e623eea0949ae0",
+        "relatedSpdxElement": "SPDXRef-File-bomctl-71fa836d87ca4748",
+        "relationshipType": "OTHER",
+        "comment": "evident-by: indicates the package's existence is evident by the given file"
+      },
+      {
+        "spdxElementId": "SPDXRef-Package-go-module-github.com-jdx-go-netrc-41e623eea0949ae0",
+        "relatedSpdxElement": "SPDXRef-Package-go-module-github.com-bomctl-bomctl-d3de1d7b912744e1",
+        "relationshipType": "DEPENDENCY_OF"
+      },
+      {
+        "spdxElementId": "SPDXRef-Package-go-module-github.com-fsnotify-fsnotify-447acb8e1eeabbd3",
+        "relatedSpdxElement": "SPDXRef-File-bomctl-71fa836d87ca4748",
+        "relationshipType": "OTHER",
+        "comment": "evident-by: indicates the package's existence is evident by the given file"
+      },
+      {
+        "spdxElementId": "SPDXRef-Package-go-module-github.com-fsnotify-fsnotify-447acb8e1eeabbd3",
+        "relatedSpdxElement": "SPDXRef-Package-go-module-github.com-bomctl-bomctl-d3de1d7b912744e1",
+        "relationshipType": "DEPENDENCY_OF"
+      },
+      {
+        "spdxElementId": "SPDXRef-Package-go-module-github.com-go-git-go-billy-v5-48d2f61b8785be50",
+        "relatedSpdxElement": "SPDXRef-File-bomctl-71fa836d87ca4748",
+        "relationshipType": "OTHER",
+        "comment": "evident-by: indicates the package's existence is evident by the given file"
+      },
+      {
+        "spdxElementId": "SPDXRef-Package-go-module-github.com-go-git-go-billy-v5-48d2f61b8785be50",
+        "relatedSpdxElement": "SPDXRef-Package-go-module-github.com-bomctl-bomctl-d3de1d7b912744e1",
+        "relationshipType": "DEPENDENCY_OF"
+      },
+      {
+        "spdxElementId": "SPDXRef-Package-go-module-github.com-spdx-tools-golang-4a08aad0b2bd69dc",
+        "relatedSpdxElement": "SPDXRef-File-bomctl-71fa836d87ca4748",
+        "relationshipType": "OTHER",
+        "comment": "evident-by: indicates the package's existence is evident by the given file"
+      },
+      {
+        "spdxElementId": "SPDXRef-Package-go-module-github.com-spdx-tools-golang-4a08aad0b2bd69dc",
+        "relatedSpdxElement": "SPDXRef-Package-go-module-github.com-bomctl-bomctl-d3de1d7b912744e1",
+        "relationshipType": "DEPENDENCY_OF"
+      },
+      {
+        "spdxElementId": "SPDXRef-Package-go-module-github.com-go-git-go-git-v5-4d148db8fd7a9c1a",
+        "relatedSpdxElement": "SPDXRef-File-bomctl-71fa836d87ca4748",
+        "relationshipType": "OTHER",
+        "comment": "evident-by: indicates the package's existence is evident by the given file"
+      },
+      {
+        "spdxElementId": "SPDXRef-Package-go-module-github.com-go-git-go-git-v5-4d148db8fd7a9c1a",
+        "relatedSpdxElement": "SPDXRef-Package-go-module-github.com-bomctl-bomctl-d3de1d7b912744e1",
+        "relationshipType": "DEPENDENCY_OF"
+      },
+      {
+        "spdxElementId": "SPDXRef-Package-go-module-github.com-zclconf-go-cty-5003adc9dafdd21d",
+        "relatedSpdxElement": "SPDXRef-File-bomctl-71fa836d87ca4748",
+        "relationshipType": "OTHER",
+        "comment": "evident-by: indicates the package's existence is evident by the given file"
+      },
+      {
+        "spdxElementId": "SPDXRef-Package-go-module-github.com-zclconf-go-cty-5003adc9dafdd21d",
+        "relatedSpdxElement": "SPDXRef-Package-go-module-github.com-bomctl-bomctl-d3de1d7b912744e1",
+        "relationshipType": "DEPENDENCY_OF"
+      },
+      {
+        "spdxElementId": "SPDXRef-Package-go-module-github.com-anchore-go-struct-converter-540179a74d1ce890",
+        "relatedSpdxElement": "SPDXRef-File-bomctl-71fa836d87ca4748",
+        "relationshipType": "OTHER",
+        "comment": "evident-by: indicates the package's existence is evident by the given file"
+      },
+      {
+        "spdxElementId": "SPDXRef-Package-go-module-github.com-anchore-go-struct-converter-540179a74d1ce890",
+        "relatedSpdxElement": "SPDXRef-Package-go-module-github.com-bomctl-bomctl-d3de1d7b912744e1",
+        "relationshipType": "DEPENDENCY_OF"
+      },
+      {
+        "spdxElementId": "SPDXRef-Package-go-module-github.com-agext-levenshtein-55b76fe4d029a0ff",
+        "relatedSpdxElement": "SPDXRef-File-bomctl-71fa836d87ca4748",
+        "relationshipType": "OTHER",
+        "comment": "evident-by: indicates the package's existence is evident by the given file"
+      },
+      {
+        "spdxElementId": "SPDXRef-Package-go-module-github.com-agext-levenshtein-55b76fe4d029a0ff",
+        "relatedSpdxElement": "SPDXRef-Package-go-module-github.com-bomctl-bomctl-d3de1d7b912744e1",
+        "relationshipType": "DEPENDENCY_OF"
+      },
+      {
+        "spdxElementId": "SPDXRef-Package-go-module-github.com-hashicorp-hcl-v2-55ff1dce30248d44",
+        "relatedSpdxElement": "SPDXRef-File-bomctl-71fa836d87ca4748",
+        "relationshipType": "OTHER",
+        "comment": "evident-by: indicates the package's existence is evident by the given file"
+      },
+      {
+        "spdxElementId": "SPDXRef-Package-go-module-github.com-hashicorp-hcl-v2-55ff1dce30248d44",
+        "relatedSpdxElement": "SPDXRef-Package-go-module-github.com-bomctl-bomctl-d3de1d7b912744e1",
+        "relationshipType": "DEPENDENCY_OF"
+      },
+      {
+        "spdxElementId": "SPDXRef-Package-go-module-github.com-spf13-afero-5ec6bf38d7bbe47e",
+        "relatedSpdxElement": "SPDXRef-File-bomctl-71fa836d87ca4748",
+        "relationshipType": "OTHER",
+        "comment": "evident-by: indicates the package's existence is evident by the given file"
+      },
+      {
+        "spdxElementId": "SPDXRef-Package-go-module-github.com-spf13-afero-5ec6bf38d7bbe47e",
+        "relatedSpdxElement": "SPDXRef-Package-go-module-github.com-bomctl-bomctl-d3de1d7b912744e1",
+        "relationshipType": "DEPENDENCY_OF"
+      },
+      {
+        "spdxElementId": "SPDXRef-Package-go-module-github.com-sergi-go-diff-5f316aebeecf261b",
+        "relatedSpdxElement": "SPDXRef-File-bomctl-71fa836d87ca4748",
+        "relationshipType": "OTHER",
+        "comment": "evident-by: indicates the package's existence is evident by the given file"
+      },
+      {
+        "spdxElementId": "SPDXRef-Package-go-module-github.com-sergi-go-diff-5f316aebeecf261b",
+        "relatedSpdxElement": "SPDXRef-Package-go-module-github.com-bomctl-bomctl-d3de1d7b912744e1",
+        "relationshipType": "DEPENDENCY_OF"
+      },
+      {
+        "spdxElementId": "SPDXRef-Package-go-module-golang.org-x-net-61049d6178cf00bc",
+        "relatedSpdxElement": "SPDXRef-File-bomctl-71fa836d87ca4748",
+        "relationshipType": "OTHER",
+        "comment": "evident-by: indicates the package's existence is evident by the given file"
+      },
+      {
+        "spdxElementId": "SPDXRef-Package-go-module-golang.org-x-net-61049d6178cf00bc",
+        "relatedSpdxElement": "SPDXRef-Package-go-module-github.com-bomctl-bomctl-d3de1d7b912744e1",
+        "relationshipType": "DEPENDENCY_OF"
+      },
+      {
+        "spdxElementId": "SPDXRef-Package-go-module-github.com-rivo-uniseg-6488b24fc2fd4ca4",
+        "relatedSpdxElement": "SPDXRef-File-bomctl-71fa836d87ca4748",
+        "relationshipType": "OTHER",
+        "comment": "evident-by: indicates the package's existence is evident by the given file"
+      },
+      {
+        "spdxElementId": "SPDXRef-Package-go-module-github.com-rivo-uniseg-6488b24fc2fd4ca4",
+        "relatedSpdxElement": "SPDXRef-Package-go-module-github.com-bomctl-bomctl-d3de1d7b912744e1",
+        "relationshipType": "DEPENDENCY_OF"
+      },
+      {
+        "spdxElementId": "SPDXRef-Package-go-module-modernc.org-memory-66ce26f959dea890",
+        "relatedSpdxElement": "SPDXRef-File-bomctl-71fa836d87ca4748",
+        "relationshipType": "OTHER",
+        "comment": "evident-by: indicates the package's existence is evident by the given file"
+      },
+      {
+        "spdxElementId": "SPDXRef-Package-go-module-modernc.org-memory-66ce26f959dea890",
+        "relatedSpdxElement": "SPDXRef-Package-go-module-github.com-bomctl-bomctl-d3de1d7b912744e1",
+        "relationshipType": "DEPENDENCY_OF"
+      },
+      {
+        "spdxElementId": "SPDXRef-Package-go-module-github.com-opencontainers-image-spec-7d27d7681ca52fa3",
+        "relatedSpdxElement": "SPDXRef-File-bomctl-71fa836d87ca4748",
+        "relationshipType": "OTHER",
+        "comment": "evident-by: indicates the package's existence is evident by the given file"
+      },
+      {
+        "spdxElementId": "SPDXRef-Package-go-module-github.com-opencontainers-image-spec-7d27d7681ca52fa3",
+        "relatedSpdxElement": "SPDXRef-Package-go-module-github.com-bomctl-bomctl-d3de1d7b912744e1",
+        "relationshipType": "DEPENDENCY_OF"
+      },
+      {
+        "spdxElementId": "SPDXRef-Package-go-module-github.com-mattn-go-isatty-7e215fce8e704dd4",
+        "relatedSpdxElement": "SPDXRef-File-bomctl-71fa836d87ca4748",
+        "relationshipType": "OTHER",
+        "comment": "evident-by: indicates the package's existence is evident by the given file"
+      },
+      {
+        "spdxElementId": "SPDXRef-Package-go-module-github.com-mattn-go-isatty-7e215fce8e704dd4",
+        "relatedSpdxElement": "SPDXRef-Package-go-module-github.com-bomctl-bomctl-d3de1d7b912744e1",
+        "relationshipType": "DEPENDENCY_OF"
+      },
+      {
+        "spdxElementId": "SPDXRef-Package-go-module-github.com-kevinburke-ssh-config-80389f8e5464d1d7",
+        "relatedSpdxElement": "SPDXRef-File-bomctl-71fa836d87ca4748",
+        "relationshipType": "OTHER",
+        "comment": "evident-by: indicates the package's existence is evident by the given file"
+      },
+      {
+        "spdxElementId": "SPDXRef-Package-go-module-github.com-kevinburke-ssh-config-80389f8e5464d1d7",
+        "relatedSpdxElement": "SPDXRef-Package-go-module-github.com-bomctl-bomctl-d3de1d7b912744e1",
+        "relationshipType": "DEPENDENCY_OF"
+      },
+      {
+        "spdxElementId": "SPDXRef-Package-go-module-github.com-dustin-go-humanize-85dfd5c83d6af7b1",
+        "relatedSpdxElement": "SPDXRef-File-bomctl-71fa836d87ca4748",
+        "relationshipType": "OTHER",
+        "comment": "evident-by: indicates the package's existence is evident by the given file"
+      },
+      {
+        "spdxElementId": "SPDXRef-Package-go-module-github.com-dustin-go-humanize-85dfd5c83d6af7b1",
+        "relatedSpdxElement": "SPDXRef-Package-go-module-github.com-bomctl-bomctl-d3de1d7b912744e1",
+        "relationshipType": "DEPENDENCY_OF"
+      },
+      {
+        "spdxElementId": "SPDXRef-Package-go-module-github.com-skeema-knownhosts-8c3e08a98640688c",
+        "relatedSpdxElement": "SPDXRef-File-bomctl-71fa836d87ca4748",
+        "relationshipType": "OTHER",
+        "comment": "evident-by: indicates the package's existence is evident by the given file"
+      },
+      {
+        "spdxElementId": "SPDXRef-Package-go-module-github.com-skeema-knownhosts-8c3e08a98640688c",
+        "relatedSpdxElement": "SPDXRef-Package-go-module-github.com-bomctl-bomctl-d3de1d7b912744e1",
+        "relationshipType": "DEPENDENCY_OF"
+      },
+      {
+        "spdxElementId": "SPDXRef-Package-go-module-github.com-common-nighthawk-go-figure-8e57ad4319ac392e",
+        "relatedSpdxElement": "SPDXRef-File-bomctl-71fa836d87ca4748",
+        "relationshipType": "OTHER",
+        "comment": "evident-by: indicates the package's existence is evident by the given file"
+      },
+      {
+        "spdxElementId": "SPDXRef-Package-go-module-github.com-common-nighthawk-go-figure-8e57ad4319ac392e",
+        "relatedSpdxElement": "SPDXRef-Package-go-module-github.com-bomctl-bomctl-d3de1d7b912744e1",
+        "relationshipType": "DEPENDENCY_OF"
+      },
+      {
+        "spdxElementId": "SPDXRef-Package-go-module-github.com-mitchellh-go-wordwrap-9653b68335c34a14",
+        "relatedSpdxElement": "SPDXRef-File-bomctl-71fa836d87ca4748",
+        "relationshipType": "OTHER",
+        "comment": "evident-by: indicates the package's existence is evident by the given file"
+      },
+      {
+        "spdxElementId": "SPDXRef-Package-go-module-github.com-mitchellh-go-wordwrap-9653b68335c34a14",
+        "relatedSpdxElement": "SPDXRef-Package-go-module-github.com-bomctl-bomctl-d3de1d7b912744e1",
+        "relationshipType": "DEPENDENCY_OF"
+      },
+      {
+        "spdxElementId": "SPDXRef-Package-go-module-github.com-google-uuid-96a219fc8f765731",
+        "relatedSpdxElement": "SPDXRef-File-bomctl-71fa836d87ca4748",
+        "relationshipType": "OTHER",
+        "comment": "evident-by: indicates the package's existence is evident by the given file"
+      },
+      {
+        "spdxElementId": "SPDXRef-Package-go-module-github.com-google-uuid-96a219fc8f765731",
+        "relatedSpdxElement": "SPDXRef-Package-go-module-github.com-bomctl-bomctl-d3de1d7b912744e1",
+        "relationshipType": "DEPENDENCY_OF"
+      },
+      {
+        "spdxElementId": "SPDXRef-Package-go-module-oras.land-oras-go-v2-9b2a46aa5362acff",
+        "relatedSpdxElement": "SPDXRef-File-bomctl-71fa836d87ca4748",
+        "relationshipType": "OTHER",
+        "comment": "evident-by: indicates the package's existence is evident by the given file"
+      },
+      {
+        "spdxElementId": "SPDXRef-Package-go-module-oras.land-oras-go-v2-9b2a46aa5362acff",
+        "relatedSpdxElement": "SPDXRef-Package-go-module-github.com-bomctl-bomctl-d3de1d7b912744e1",
+        "relationshipType": "DEPENDENCY_OF"
+      },
+      {
+        "spdxElementId": "SPDXRef-Package-go-module-github.com-cloudflare-circl-9c57f98a584dee03",
+        "relatedSpdxElement": "SPDXRef-File-bomctl-71fa836d87ca4748",
+        "relationshipType": "OTHER",
+        "comment": "evident-by: indicates the package's existence is evident by the given file"
+      },
+      {
+        "spdxElementId": "SPDXRef-Package-go-module-github.com-cloudflare-circl-9c57f98a584dee03",
+        "relatedSpdxElement": "SPDXRef-Package-go-module-github.com-bomctl-bomctl-d3de1d7b912744e1",
+        "relationshipType": "DEPENDENCY_OF"
+      },
+      {
+        "spdxElementId": "SPDXRef-Package-go-module-github.com-charmbracelet-x-ansi-a27a9a0d7ea9f3de",
+        "relatedSpdxElement": "SPDXRef-File-bomctl-71fa836d87ca4748",
+        "relationshipType": "OTHER",
+        "comment": "evident-by: indicates the package's existence is evident by the given file"
+      },
+      {
+        "spdxElementId": "SPDXRef-Package-go-module-github.com-charmbracelet-x-ansi-a27a9a0d7ea9f3de",
+        "relatedSpdxElement": "SPDXRef-Package-go-module-github.com-bomctl-bomctl-d3de1d7b912744e1",
+        "relationshipType": "DEPENDENCY_OF"
+      },
+      {
+        "spdxElementId": "SPDXRef-Package-go-module-github.com-hashicorp-hcl-aa3f0391aca480a4",
+        "relatedSpdxElement": "SPDXRef-File-bomctl-71fa836d87ca4748",
+        "relationshipType": "OTHER",
+        "comment": "evident-by: indicates the package's existence is evident by the given file"
+      },
+      {
+        "spdxElementId": "SPDXRef-Package-go-module-github.com-hashicorp-hcl-aa3f0391aca480a4",
+        "relatedSpdxElement": "SPDXRef-Package-go-module-github.com-bomctl-bomctl-d3de1d7b912744e1",
+        "relationshipType": "DEPENDENCY_OF"
+      },
+      {
+        "spdxElementId": "SPDXRef-Package-go-module-github.com-spf13-cobra-abc1a0131d6432f9",
+        "relatedSpdxElement": "SPDXRef-File-bomctl-71fa836d87ca4748",
+        "relationshipType": "OTHER",
+        "comment": "evident-by: indicates the package's existence is evident by the given file"
+      },
+      {
+        "spdxElementId": "SPDXRef-Package-go-module-github.com-spf13-cobra-abc1a0131d6432f9",
+        "relatedSpdxElement": "SPDXRef-Package-go-module-github.com-bomctl-bomctl-d3de1d7b912744e1",
+        "relationshipType": "DEPENDENCY_OF"
+      },
+      {
+        "spdxElementId": "SPDXRef-Package-go-module-github.com-opencontainers-go-digest-acdedc5890713dd2",
+        "relatedSpdxElement": "SPDXRef-File-bomctl-71fa836d87ca4748",
+        "relationshipType": "OTHER",
+        "comment": "evident-by: indicates the package's existence is evident by the given file"
+      },
+      {
+        "spdxElementId": "SPDXRef-Package-go-module-github.com-opencontainers-go-digest-acdedc5890713dd2",
+        "relatedSpdxElement": "SPDXRef-Package-go-module-github.com-bomctl-bomctl-d3de1d7b912744e1",
+        "relationshipType": "DEPENDENCY_OF"
+      },
+      {
+        "spdxElementId": "SPDXRef-Package-go-module-github.com-glebarez-go-sqlite-ad729fe4f3e5643f",
+        "relatedSpdxElement": "SPDXRef-File-bomctl-71fa836d87ca4748",
+        "relationshipType": "OTHER",
+        "comment": "evident-by: indicates the package's existence is evident by the given file"
+      },
+      {
+        "spdxElementId": "SPDXRef-Package-go-module-github.com-glebarez-go-sqlite-ad729fe4f3e5643f",
+        "relatedSpdxElement": "SPDXRef-Package-go-module-github.com-bomctl-bomctl-d3de1d7b912744e1",
+        "relationshipType": "DEPENDENCY_OF"
+      },
+      {
+        "spdxElementId": "SPDXRef-Package-go-module-github.com-go-git-gcfg-ae7765da897ccf62",
+        "relatedSpdxElement": "SPDXRef-File-bomctl-71fa836d87ca4748",
+        "relationshipType": "OTHER",
+        "comment": "evident-by: indicates the package's existence is evident by the given file"
+      },
+      {
+        "spdxElementId": "SPDXRef-Package-go-module-github.com-go-git-gcfg-ae7765da897ccf62",
+        "relatedSpdxElement": "SPDXRef-Package-go-module-github.com-bomctl-bomctl-d3de1d7b912744e1",
+        "relationshipType": "DEPENDENCY_OF"
+      },
+      {
+        "spdxElementId": "SPDXRef-Package-go-module-github.com-remyoudompheng-bigfft-af00bbfe7ea65ca7",
+        "relatedSpdxElement": "SPDXRef-File-bomctl-71fa836d87ca4748",
+        "relationshipType": "OTHER",
+        "comment": "evident-by: indicates the package's existence is evident by the given file"
+      },
+      {
+        "spdxElementId": "SPDXRef-Package-go-module-github.com-remyoudompheng-bigfft-af00bbfe7ea65ca7",
+        "relatedSpdxElement": "SPDXRef-Package-go-module-github.com-bomctl-bomctl-d3de1d7b912744e1",
+        "relationshipType": "DEPENDENCY_OF"
+      },
+      {
+        "spdxElementId": "SPDXRef-Package-go-module-github.com-pjbgf-sha1cd-b19c6cb88557f8bd",
+        "relatedSpdxElement": "SPDXRef-File-bomctl-71fa836d87ca4748",
+        "relationshipType": "OTHER",
+        "comment": "evident-by: indicates the package's existence is evident by the given file"
+      },
+      {
+        "spdxElementId": "SPDXRef-Package-go-module-github.com-pjbgf-sha1cd-b19c6cb88557f8bd",
+        "relatedSpdxElement": "SPDXRef-Package-go-module-github.com-bomctl-bomctl-d3de1d7b912744e1",
+        "relationshipType": "DEPENDENCY_OF"
+      },
+      {
+        "spdxElementId": "SPDXRef-Package-go-module-github.com-google-go-cmp-b6d176695d69491a",
+        "relatedSpdxElement": "SPDXRef-File-bomctl-71fa836d87ca4748",
+        "relationshipType": "OTHER",
+        "comment": "evident-by: indicates the package's existence is evident by the given file"
+      },
+      {
+        "spdxElementId": "SPDXRef-Package-go-module-github.com-google-go-cmp-b6d176695d69491a",
+        "relatedSpdxElement": "SPDXRef-Package-go-module-github.com-bomctl-bomctl-d3de1d7b912744e1",
+        "relationshipType": "DEPENDENCY_OF"
+      },
+      {
+        "spdxElementId": "SPDXRef-Package-go-module-modernc.org-libc-b7512b701a20d0b3",
+        "relatedSpdxElement": "SPDXRef-File-bomctl-71fa836d87ca4748",
+        "relationshipType": "OTHER",
+        "comment": "evident-by: indicates the package's existence is evident by the given file"
+      },
+      {
+        "spdxElementId": "SPDXRef-Package-go-module-modernc.org-libc-b7512b701a20d0b3",
+        "relatedSpdxElement": "SPDXRef-Package-go-module-github.com-bomctl-bomctl-d3de1d7b912744e1",
+        "relationshipType": "DEPENDENCY_OF"
+      },
+      {
+        "spdxElementId": "SPDXRef-Package-go-module-github.com-magiconair-properties-bb59395879b78628",
+        "relatedSpdxElement": "SPDXRef-File-bomctl-71fa836d87ca4748",
+        "relationshipType": "OTHER",
+        "comment": "evident-by: indicates the package's existence is evident by the given file"
+      },
+      {
+        "spdxElementId": "SPDXRef-Package-go-module-github.com-magiconair-properties-bb59395879b78628",
+        "relatedSpdxElement": "SPDXRef-Package-go-module-github.com-bomctl-bomctl-d3de1d7b912744e1",
+        "relationshipType": "DEPENDENCY_OF"
+      },
+      {
+        "spdxElementId": "SPDXRef-Package-go-module-github.com-protobom-protobom-c6092a35d4046627",
+        "relatedSpdxElement": "SPDXRef-File-bomctl-71fa836d87ca4748",
+        "relationshipType": "OTHER",
+        "comment": "evident-by: indicates the package's existence is evident by the given file"
+      },
+      {
+        "spdxElementId": "SPDXRef-Package-go-module-github.com-protobom-protobom-c6092a35d4046627",
+        "relatedSpdxElement": "SPDXRef-Package-go-module-github.com-bomctl-bomctl-d3de1d7b912744e1",
+        "relationshipType": "DEPENDENCY_OF"
+      },
+      {
+        "spdxElementId": "SPDXRef-Package-go-module-ariga.io-atlas-c7e8a33efe528bcd",
+        "relatedSpdxElement": "SPDXRef-File-bomctl-71fa836d87ca4748",
+        "relationshipType": "OTHER",
+        "comment": "evident-by: indicates the package's existence is evident by the given file"
+      },
+      {
+        "spdxElementId": "SPDXRef-Package-go-module-ariga.io-atlas-c7e8a33efe528bcd",
+        "relatedSpdxElement": "SPDXRef-Package-go-module-github.com-bomctl-bomctl-d3de1d7b912744e1",
+        "relationshipType": "DEPENDENCY_OF"
+      },
+      {
+        "spdxElementId": "SPDXRef-Package-go-module-github.com-sirupsen-logrus-c9d8b46f2f6f848a",
+        "relatedSpdxElement": "SPDXRef-File-bomctl-71fa836d87ca4748",
+        "relationshipType": "OTHER",
+        "comment": "evident-by: indicates the package's existence is evident by the given file"
+      },
+      {
+        "spdxElementId": "SPDXRef-Package-go-module-github.com-sirupsen-logrus-c9d8b46f2f6f848a",
+        "relatedSpdxElement": "SPDXRef-Package-go-module-github.com-bomctl-bomctl-d3de1d7b912744e1",
+        "relationshipType": "DEPENDENCY_OF"
+      },
+      {
+        "spdxElementId": "SPDXRef-Package-go-module-golang.org-x-crypto-cad8ee1f69d6ff20",
+        "relatedSpdxElement": "SPDXRef-File-bomctl-71fa836d87ca4748",
+        "relationshipType": "OTHER",
+        "comment": "evident-by: indicates the package's existence is evident by the given file"
+      },
+      {
+        "spdxElementId": "SPDXRef-Package-go-module-golang.org-x-crypto-cad8ee1f69d6ff20",
+        "relatedSpdxElement": "SPDXRef-Package-go-module-github.com-bomctl-bomctl-d3de1d7b912744e1",
+        "relationshipType": "DEPENDENCY_OF"
+      },
+      {
+        "spdxElementId": "SPDXRef-Package-go-module-gopkg.in-yaml.v3-cb259ab751a0f22e",
+        "relatedSpdxElement": "SPDXRef-File-bomctl-71fa836d87ca4748",
+        "relationshipType": "OTHER",
+        "comment": "evident-by: indicates the package's existence is evident by the given file"
+      },
+      {
+        "spdxElementId": "SPDXRef-Package-go-module-gopkg.in-yaml.v3-cb259ab751a0f22e",
+        "relatedSpdxElement": "SPDXRef-Package-go-module-github.com-bomctl-bomctl-d3de1d7b912744e1",
+        "relationshipType": "DEPENDENCY_OF"
+      },
+      {
+        "spdxElementId": "SPDXRef-Package-go-module-github.com-mattn-go-runewidth-ce6e3b6b4e625eff",
+        "relatedSpdxElement": "SPDXRef-File-bomctl-71fa836d87ca4748",
+        "relationshipType": "OTHER",
+        "comment": "evident-by: indicates the package's existence is evident by the given file"
+      },
+      {
+        "spdxElementId": "SPDXRef-Package-go-module-github.com-mattn-go-runewidth-ce6e3b6b4e625eff",
+        "relatedSpdxElement": "SPDXRef-Package-go-module-github.com-bomctl-bomctl-d3de1d7b912744e1",
+        "relationshipType": "DEPENDENCY_OF"
+      },
+      {
+        "spdxElementId": "SPDXRef-Package-go-module-github.com-mitchellh-mapstructure-ce92bf8494f7c701",
+        "relatedSpdxElement": "SPDXRef-File-bomctl-71fa836d87ca4748",
+        "relationshipType": "OTHER",
+        "comment": "evident-by: indicates the package's existence is evident by the given file"
+      },
+      {
+        "spdxElementId": "SPDXRef-Package-go-module-github.com-mitchellh-mapstructure-ce92bf8494f7c701",
+        "relatedSpdxElement": "SPDXRef-Package-go-module-github.com-bomctl-bomctl-d3de1d7b912744e1",
+        "relationshipType": "DEPENDENCY_OF"
+      },
+      {
+        "spdxElementId": "SPDXRef-Package-go-module-github.com-muesli-termenv-cfc0e1203c415e26",
+        "relatedSpdxElement": "SPDXRef-File-bomctl-71fa836d87ca4748",
+        "relationshipType": "OTHER",
+        "comment": "evident-by: indicates the package's existence is evident by the given file"
+      },
+      {
+        "spdxElementId": "SPDXRef-Package-go-module-github.com-muesli-termenv-cfc0e1203c415e26",
+        "relatedSpdxElement": "SPDXRef-Package-go-module-github.com-bomctl-bomctl-d3de1d7b912744e1",
+        "relationshipType": "DEPENDENCY_OF"
+      },
+      {
+        "spdxElementId": "SPDXRef-Package-go-module-github.com-emirpasic-gods-d22c5cfa09b1d538",
+        "relatedSpdxElement": "SPDXRef-File-bomctl-71fa836d87ca4748",
+        "relationshipType": "OTHER",
+        "comment": "evident-by: indicates the package's existence is evident by the given file"
+      },
+      {
+        "spdxElementId": "SPDXRef-Package-go-module-github.com-emirpasic-gods-d22c5cfa09b1d538",
+        "relatedSpdxElement": "SPDXRef-Package-go-module-github.com-bomctl-bomctl-d3de1d7b912744e1",
+        "relationshipType": "DEPENDENCY_OF"
+      },
+      {
+        "spdxElementId": "SPDXRef-Package-go-module-github.com-bomctl-bomctl-d3de1d7b912744e1",
+        "relatedSpdxElement": "SPDXRef-File-bomctl-71fa836d87ca4748",
+        "relationshipType": "OTHER",
+        "comment": "evident-by: indicates the package's existence is evident by the given file"
+      },
+      {
+        "spdxElementId": "SPDXRef-Package-go-module-github.com-cyphar-filepath-securejoin-d3deffed50138a27",
+        "relatedSpdxElement": "SPDXRef-File-bomctl-71fa836d87ca4748",
+        "relationshipType": "OTHER",
+        "comment": "evident-by: indicates the package's existence is evident by the given file"
+      },
+      {
+        "spdxElementId": "SPDXRef-Package-go-module-github.com-cyphar-filepath-securejoin-d3deffed50138a27",
+        "relatedSpdxElement": "SPDXRef-Package-go-module-github.com-bomctl-bomctl-d3de1d7b912744e1",
+        "relationshipType": "DEPENDENCY_OF"
+      },
+      {
+        "spdxElementId": "SPDXRef-Package-go-module-google.golang.org-protobuf-d430c7a0e4539ea4",
+        "relatedSpdxElement": "SPDXRef-File-bomctl-71fa836d87ca4748",
+        "relationshipType": "OTHER",
+        "comment": "evident-by: indicates the package's existence is evident by the given file"
+      },
+      {
+        "spdxElementId": "SPDXRef-Package-go-module-google.golang.org-protobuf-d430c7a0e4539ea4",
+        "relatedSpdxElement": "SPDXRef-Package-go-module-github.com-bomctl-bomctl-d3de1d7b912744e1",
+        "relationshipType": "DEPENDENCY_OF"
+      },
+      {
+        "spdxElementId": "SPDXRef-Package-go-module-golang.org-x-sys-d48df6a309bf0b5a",
+        "relatedSpdxElement": "SPDXRef-File-bomctl-71fa836d87ca4748",
+        "relationshipType": "OTHER",
+        "comment": "evident-by: indicates the package's existence is evident by the given file"
+      },
+      {
+        "spdxElementId": "SPDXRef-Package-go-module-golang.org-x-sys-d48df6a309bf0b5a",
+        "relatedSpdxElement": "SPDXRef-Package-go-module-github.com-bomctl-bomctl-d3de1d7b912744e1",
+        "relationshipType": "DEPENDENCY_OF"
+      },
+      {
+        "spdxElementId": "SPDXRef-Package-go-module-gopkg.in-ini.v1-d4dcf7d18233628d",
+        "relatedSpdxElement": "SPDXRef-File-bomctl-71fa836d87ca4748",
+        "relationshipType": "OTHER",
+        "comment": "evident-by: indicates the package's existence is evident by the given file"
+      },
+      {
+        "spdxElementId": "SPDXRef-Package-go-module-gopkg.in-ini.v1-d4dcf7d18233628d",
+        "relatedSpdxElement": "SPDXRef-Package-go-module-github.com-bomctl-bomctl-d3de1d7b912744e1",
+        "relationshipType": "DEPENDENCY_OF"
+      },
+      {
+        "spdxElementId": "SPDXRef-Package-go-module-dario.cat-mergo-d5fcd2c2377a1cd1",
+        "relatedSpdxElement": "SPDXRef-File-bomctl-71fa836d87ca4748",
+        "relationshipType": "OTHER",
+        "comment": "evident-by: indicates the package's existence is evident by the given file"
+      },
+      {
+        "spdxElementId": "SPDXRef-Package-go-module-dario.cat-mergo-d5fcd2c2377a1cd1",
+        "relatedSpdxElement": "SPDXRef-Package-go-module-github.com-bomctl-bomctl-d3de1d7b912744e1",
+        "relationshipType": "DEPENDENCY_OF"
+      },
+      {
+        "spdxElementId": "SPDXRef-Package-go-module-github.com-blang-semver-v4-d63527ef931efe69",
+        "relatedSpdxElement": "SPDXRef-File-bomctl-71fa836d87ca4748",
+        "relationshipType": "OTHER",
+        "comment": "evident-by: indicates the package's existence is evident by the given file"
+      },
+      {
+        "spdxElementId": "SPDXRef-Package-go-module-github.com-blang-semver-v4-d63527ef931efe69",
+        "relatedSpdxElement": "SPDXRef-Package-go-module-github.com-bomctl-bomctl-d3de1d7b912744e1",
+        "relationshipType": "DEPENDENCY_OF"
+      },
+      {
+        "spdxElementId": "SPDXRef-Package-go-module-modernc.org-mathutil-dcbd9a97ad7457a1",
+        "relatedSpdxElement": "SPDXRef-File-bomctl-71fa836d87ca4748",
+        "relationshipType": "OTHER",
+        "comment": "evident-by: indicates the package's existence is evident by the given file"
+      },
+      {
+        "spdxElementId": "SPDXRef-Package-go-module-modernc.org-mathutil-dcbd9a97ad7457a1",
+        "relatedSpdxElement": "SPDXRef-Package-go-module-github.com-bomctl-bomctl-d3de1d7b912744e1",
+        "relationshipType": "DEPENDENCY_OF"
+      },
+      {
+        "spdxElementId": "SPDXRef-Package-go-module-github.com-spf13-viper-ee2f520636d42a46",
+        "relatedSpdxElement": "SPDXRef-File-bomctl-71fa836d87ca4748",
+        "relationshipType": "OTHER",
+        "comment": "evident-by: indicates the package's existence is evident by the given file"
+      },
+      {
+        "spdxElementId": "SPDXRef-Package-go-module-github.com-spf13-viper-ee2f520636d42a46",
+        "relatedSpdxElement": "SPDXRef-Package-go-module-github.com-bomctl-bomctl-d3de1d7b912744e1",
+        "relationshipType": "DEPENDENCY_OF"
+      },
+      {
+        "spdxElementId": "SPDXRef-Package-go-module-golang.org-x-sync-f3affac3cfb945cc",
+        "relatedSpdxElement": "SPDXRef-File-bomctl-71fa836d87ca4748",
+        "relationshipType": "OTHER",
+        "comment": "evident-by: indicates the package's existence is evident by the given file"
+      },
+      {
+        "spdxElementId": "SPDXRef-Package-go-module-golang.org-x-sync-f3affac3cfb945cc",
+        "relatedSpdxElement": "SPDXRef-Package-go-module-github.com-bomctl-bomctl-d3de1d7b912744e1",
+        "relationshipType": "DEPENDENCY_OF"
+      },
+      {
+        "spdxElementId": "SPDXRef-Package-go-module-github.com-protobom-storage-f53e9cde5f8d751c",
+        "relatedSpdxElement": "SPDXRef-File-bomctl-71fa836d87ca4748",
+        "relationshipType": "OTHER",
+        "comment": "evident-by: indicates the package's existence is evident by the given file"
+      },
+      {
+        "spdxElementId": "SPDXRef-Package-go-module-github.com-protobom-storage-f53e9cde5f8d751c",
+        "relatedSpdxElement": "SPDXRef-Package-go-module-github.com-bomctl-bomctl-d3de1d7b912744e1",
+        "relationshipType": "DEPENDENCY_OF"
+      },
+      {
+        "spdxElementId": "SPDXRef-Package-go-module-github.com-spf13-cast-f6387b9a391d383c",
+        "relatedSpdxElement": "SPDXRef-File-bomctl-71fa836d87ca4748",
+        "relationshipType": "OTHER",
+        "comment": "evident-by: indicates the package's existence is evident by the given file"
+      },
+      {
+        "spdxElementId": "SPDXRef-Package-go-module-github.com-spf13-cast-f6387b9a391d383c",
+        "relatedSpdxElement": "SPDXRef-Package-go-module-github.com-bomctl-bomctl-d3de1d7b912744e1",
+        "relationshipType": "DEPENDENCY_OF"
+      },
+      {
+        "spdxElementId": "SPDXRef-Package-go-module-github.com-sagikazarmark-slog-shim-f8702e09f858dfb5",
+        "relatedSpdxElement": "SPDXRef-File-bomctl-71fa836d87ca4748",
+        "relationshipType": "OTHER",
+        "comment": "evident-by: indicates the package's existence is evident by the given file"
+      },
+      {
+        "spdxElementId": "SPDXRef-Package-go-module-github.com-sagikazarmark-slog-shim-f8702e09f858dfb5",
+        "relatedSpdxElement": "SPDXRef-Package-go-module-github.com-bomctl-bomctl-d3de1d7b912744e1",
+        "relationshipType": "DEPENDENCY_OF"
+      },
+      {
+        "spdxElementId": "SPDXRef-Package-go-module-stdlib-f9d1785bc3385da5",
+        "relatedSpdxElement": "SPDXRef-File-bomctl-71fa836d87ca4748",
+        "relationshipType": "OTHER",
+        "comment": "evident-by: indicates the package's existence is evident by the given file"
+      },
+      {
+        "spdxElementId": "SPDXRef-Package-go-module-stdlib-f9d1785bc3385da5",
+        "relatedSpdxElement": "SPDXRef-Package-go-module-github.com-bomctl-bomctl-d3de1d7b912744e1",
+        "relationshipType": "DEPENDENCY_OF"
+      },
+      {
+        "spdxElementId": "SPDXRef-Package-go-module-github.com-aymanbagabas-go-osc52-v2-fb00d93211f62e73",
+        "relatedSpdxElement": "SPDXRef-File-bomctl-71fa836d87ca4748",
+        "relationshipType": "OTHER",
+        "comment": "evident-by: indicates the package's existence is evident by the given file"
+      },
+      {
+        "spdxElementId": "SPDXRef-Package-go-module-github.com-aymanbagabas-go-osc52-v2-fb00d93211f62e73",
+        "relatedSpdxElement": "SPDXRef-Package-go-module-github.com-bomctl-bomctl-d3de1d7b912744e1",
+        "relationshipType": "DEPENDENCY_OF"
+      },
+      {
+        "spdxElementId": "SPDXRef-Package-go-module-github.com-lucasb-eyer-go-colorful-fbed168999279944",
+        "relatedSpdxElement": "SPDXRef-File-bomctl-71fa836d87ca4748",
+        "relationshipType": "OTHER",
+        "comment": "evident-by: indicates the package's existence is evident by the given file"
+      },
+      {
+        "spdxElementId": "SPDXRef-Package-go-module-github.com-lucasb-eyer-go-colorful-fbed168999279944",
+        "relatedSpdxElement": "SPDXRef-Package-go-module-github.com-bomctl-bomctl-d3de1d7b912744e1",
+        "relationshipType": "DEPENDENCY_OF"
+      },
+      {
+        "spdxElementId": "SPDXRef-Package-go-module-github.com-xanzy-ssh-agent-fc817718385f3705",
+        "relatedSpdxElement": "SPDXRef-File-bomctl-71fa836d87ca4748",
+        "relationshipType": "OTHER",
+        "comment": "evident-by: indicates the package's existence is evident by the given file"
+      },
+      {
+        "spdxElementId": "SPDXRef-Package-go-module-github.com-xanzy-ssh-agent-fc817718385f3705",
+        "relatedSpdxElement": "SPDXRef-Package-go-module-github.com-bomctl-bomctl-d3de1d7b912744e1",
+        "relationshipType": "DEPENDENCY_OF"
+      },
+      {
+        "spdxElementId": "SPDXRef-Package-go-module-github.com-subosito-gotenv-fcb83a5920e185c4",
+        "relatedSpdxElement": "SPDXRef-File-bomctl-71fa836d87ca4748",
+        "relationshipType": "OTHER",
+        "comment": "evident-by: indicates the package's existence is evident by the given file"
+      },
+      {
+        "spdxElementId": "SPDXRef-Package-go-module-github.com-subosito-gotenv-fcb83a5920e185c4",
+        "relatedSpdxElement": "SPDXRef-Package-go-module-github.com-bomctl-bomctl-d3de1d7b912744e1",
+        "relationshipType": "DEPENDENCY_OF"
+      },
+      {
+        "spdxElementId": "SPDXRef-DocumentRoot-File-bomctl-0.3.0-darwin-arm64.tar.gz",
+        "relatedSpdxElement": "SPDXRef-Package-go-module-ariga.io-atlas-c7e8a33efe528bcd",
+        "relationshipType": "CONTAINS"
+      },
+      {
+        "spdxElementId": "SPDXRef-DocumentRoot-File-bomctl-0.3.0-darwin-arm64.tar.gz",
+        "relatedSpdxElement": "SPDXRef-Package-go-module-dario.cat-mergo-d5fcd2c2377a1cd1",
+        "relationshipType": "CONTAINS"
+      },
+      {
+        "spdxElementId": "SPDXRef-DocumentRoot-File-bomctl-0.3.0-darwin-arm64.tar.gz",
+        "relatedSpdxElement": "SPDXRef-Package-go-module-entgo.io-ent-2f326bd8f7351e93",
+        "relationshipType": "CONTAINS"
+      },
+      {
+        "spdxElementId": "SPDXRef-DocumentRoot-File-bomctl-0.3.0-darwin-arm64.tar.gz",
+        "relatedSpdxElement": "SPDXRef-Package-go-module-github.com-CycloneDX-cyclonedx-go-123d16cf974edfaa",
+        "relationshipType": "CONTAINS"
+      },
+      {
+        "spdxElementId": "SPDXRef-DocumentRoot-File-bomctl-0.3.0-darwin-arm64.tar.gz",
+        "relatedSpdxElement": "SPDXRef-Package-go-module-github.com-ProtonMail-go-crypto-0ed0e0ef656bde63",
+        "relationshipType": "CONTAINS"
+      },
+      {
+        "spdxElementId": "SPDXRef-DocumentRoot-File-bomctl-0.3.0-darwin-arm64.tar.gz",
+        "relatedSpdxElement": "SPDXRef-Package-go-module-github.com-agext-levenshtein-55b76fe4d029a0ff",
+        "relationshipType": "CONTAINS"
+      },
+      {
+        "spdxElementId": "SPDXRef-DocumentRoot-File-bomctl-0.3.0-darwin-arm64.tar.gz",
+        "relatedSpdxElement": "SPDXRef-Package-go-module-github.com-anchore-go-struct-converter-540179a74d1ce890",
+        "relationshipType": "CONTAINS"
+      },
+      {
+        "spdxElementId": "SPDXRef-DocumentRoot-File-bomctl-0.3.0-darwin-arm64.tar.gz",
+        "relatedSpdxElement": "SPDXRef-Package-go-module-github.com-apparentlymart-go-textseg-v13-1c79ce3d5e07ff7f",
+        "relationshipType": "CONTAINS"
+      },
+      {
+        "spdxElementId": "SPDXRef-DocumentRoot-File-bomctl-0.3.0-darwin-arm64.tar.gz",
+        "relatedSpdxElement": "SPDXRef-Package-go-module-github.com-aymanbagabas-go-osc52-v2-fb00d93211f62e73",
+        "relationshipType": "CONTAINS"
+      },
+      {
+        "spdxElementId": "SPDXRef-DocumentRoot-File-bomctl-0.3.0-darwin-arm64.tar.gz",
+        "relatedSpdxElement": "SPDXRef-Package-go-module-github.com-blang-semver-v4-d63527ef931efe69",
+        "relationshipType": "CONTAINS"
+      },
+      {
+        "spdxElementId": "SPDXRef-DocumentRoot-File-bomctl-0.3.0-darwin-arm64.tar.gz",
+        "relatedSpdxElement": "SPDXRef-Package-go-module-github.com-bomctl-bomctl-d3de1d7b912744e1",
+        "relationshipType": "CONTAINS"
+      },
+      {
+        "spdxElementId": "SPDXRef-DocumentRoot-File-bomctl-0.3.0-darwin-arm64.tar.gz",
+        "relatedSpdxElement": "SPDXRef-Package-go-module-github.com-charmbracelet-lipgloss-3c246a3a04019348",
+        "relationshipType": "CONTAINS"
+      },
+      {
+        "spdxElementId": "SPDXRef-DocumentRoot-File-bomctl-0.3.0-darwin-arm64.tar.gz",
+        "relatedSpdxElement": "SPDXRef-Package-go-module-github.com-charmbracelet-log-230150632de127f8",
+        "relationshipType": "CONTAINS"
+      },
+      {
+        "spdxElementId": "SPDXRef-DocumentRoot-File-bomctl-0.3.0-darwin-arm64.tar.gz",
+        "relatedSpdxElement": "SPDXRef-Package-go-module-github.com-charmbracelet-x-ansi-a27a9a0d7ea9f3de",
+        "relationshipType": "CONTAINS"
+      },
+      {
+        "spdxElementId": "SPDXRef-DocumentRoot-File-bomctl-0.3.0-darwin-arm64.tar.gz",
+        "relatedSpdxElement": "SPDXRef-Package-go-module-github.com-cloudflare-circl-9c57f98a584dee03",
+        "relationshipType": "CONTAINS"
+      },
+      {
+        "spdxElementId": "SPDXRef-DocumentRoot-File-bomctl-0.3.0-darwin-arm64.tar.gz",
+        "relatedSpdxElement": "SPDXRef-Package-go-module-github.com-common-nighthawk-go-figure-8e57ad4319ac392e",
+        "relationshipType": "CONTAINS"
+      },
+      {
+        "spdxElementId": "SPDXRef-DocumentRoot-File-bomctl-0.3.0-darwin-arm64.tar.gz",
+        "relatedSpdxElement": "SPDXRef-Package-go-module-github.com-cyphar-filepath-securejoin-d3deffed50138a27",
+        "relationshipType": "CONTAINS"
+      },
+      {
+        "spdxElementId": "SPDXRef-DocumentRoot-File-bomctl-0.3.0-darwin-arm64.tar.gz",
+        "relatedSpdxElement": "SPDXRef-Package-go-module-github.com-dustin-go-humanize-85dfd5c83d6af7b1",
+        "relationshipType": "CONTAINS"
+      },
+      {
+        "spdxElementId": "SPDXRef-DocumentRoot-File-bomctl-0.3.0-darwin-arm64.tar.gz",
+        "relatedSpdxElement": "SPDXRef-Package-go-module-github.com-emirpasic-gods-d22c5cfa09b1d538",
+        "relationshipType": "CONTAINS"
+      },
+      {
+        "spdxElementId": "SPDXRef-DocumentRoot-File-bomctl-0.3.0-darwin-arm64.tar.gz",
+        "relatedSpdxElement": "SPDXRef-Package-go-module-github.com-fsnotify-fsnotify-447acb8e1eeabbd3",
+        "relationshipType": "CONTAINS"
+      },
+      {
+        "spdxElementId": "SPDXRef-DocumentRoot-File-bomctl-0.3.0-darwin-arm64.tar.gz",
+        "relatedSpdxElement": "SPDXRef-Package-go-module-github.com-glebarez-go-sqlite-ad729fe4f3e5643f",
+        "relationshipType": "CONTAINS"
+      },
+      {
+        "spdxElementId": "SPDXRef-DocumentRoot-File-bomctl-0.3.0-darwin-arm64.tar.gz",
+        "relatedSpdxElement": "SPDXRef-Package-go-module-github.com-go-git-gcfg-ae7765da897ccf62",
+        "relationshipType": "CONTAINS"
+      },
+      {
+        "spdxElementId": "SPDXRef-DocumentRoot-File-bomctl-0.3.0-darwin-arm64.tar.gz",
+        "relatedSpdxElement": "SPDXRef-Package-go-module-github.com-go-git-go-billy-v5-48d2f61b8785be50",
+        "relationshipType": "CONTAINS"
+      },
+      {
+        "spdxElementId": "SPDXRef-DocumentRoot-File-bomctl-0.3.0-darwin-arm64.tar.gz",
+        "relatedSpdxElement": "SPDXRef-Package-go-module-github.com-go-git-go-git-v5-4d148db8fd7a9c1a",
+        "relationshipType": "CONTAINS"
+      },
+      {
+        "spdxElementId": "SPDXRef-DocumentRoot-File-bomctl-0.3.0-darwin-arm64.tar.gz",
+        "relatedSpdxElement": "SPDXRef-Package-go-module-github.com-go-logfmt-logfmt-28cc7b512b5b0b8a",
+        "relationshipType": "CONTAINS"
+      },
+      {
+        "spdxElementId": "SPDXRef-DocumentRoot-File-bomctl-0.3.0-darwin-arm64.tar.gz",
+        "relatedSpdxElement": "SPDXRef-Package-go-module-github.com-go-openapi-inflect-04ffedb8f70e9170",
+        "relationshipType": "CONTAINS"
+      },
+      {
+        "spdxElementId": "SPDXRef-DocumentRoot-File-bomctl-0.3.0-darwin-arm64.tar.gz",
+        "relatedSpdxElement": "SPDXRef-Package-go-module-github.com-golang-groupcache-0dceeab7e0e706b1",
+        "relationshipType": "CONTAINS"
+      },
+      {
+        "spdxElementId": "SPDXRef-DocumentRoot-File-bomctl-0.3.0-darwin-arm64.tar.gz",
+        "relatedSpdxElement": "SPDXRef-Package-go-module-github.com-google-go-cmp-b6d176695d69491a",
+        "relationshipType": "CONTAINS"
+      },
+      {
+        "spdxElementId": "SPDXRef-DocumentRoot-File-bomctl-0.3.0-darwin-arm64.tar.gz",
+        "relatedSpdxElement": "SPDXRef-Package-go-module-github.com-google-uuid-96a219fc8f765731",
+        "relationshipType": "CONTAINS"
+      },
+      {
+        "spdxElementId": "SPDXRef-DocumentRoot-File-bomctl-0.3.0-darwin-arm64.tar.gz",
+        "relatedSpdxElement": "SPDXRef-Package-go-module-github.com-hashicorp-hcl-aa3f0391aca480a4",
+        "relationshipType": "CONTAINS"
+      },
+      {
+        "spdxElementId": "SPDXRef-DocumentRoot-File-bomctl-0.3.0-darwin-arm64.tar.gz",
+        "relatedSpdxElement": "SPDXRef-Package-go-module-github.com-hashicorp-hcl-v2-55ff1dce30248d44",
+        "relationshipType": "CONTAINS"
+      },
+      {
+        "spdxElementId": "SPDXRef-DocumentRoot-File-bomctl-0.3.0-darwin-arm64.tar.gz",
+        "relatedSpdxElement": "SPDXRef-Package-go-module-github.com-jbenet-go-context-27b65da1f0dfe16d",
+        "relationshipType": "CONTAINS"
+      },
+      {
+        "spdxElementId": "SPDXRef-DocumentRoot-File-bomctl-0.3.0-darwin-arm64.tar.gz",
+        "relatedSpdxElement": "SPDXRef-Package-go-module-github.com-jdx-go-netrc-41e623eea0949ae0",
+        "relationshipType": "CONTAINS"
+      },
+      {
+        "spdxElementId": "SPDXRef-DocumentRoot-File-bomctl-0.3.0-darwin-arm64.tar.gz",
+        "relatedSpdxElement": "SPDXRef-Package-go-module-github.com-kevinburke-ssh-config-80389f8e5464d1d7",
+        "relationshipType": "CONTAINS"
+      },
+      {
+        "spdxElementId": "SPDXRef-DocumentRoot-File-bomctl-0.3.0-darwin-arm64.tar.gz",
+        "relatedSpdxElement": "SPDXRef-Package-go-module-github.com-lucasb-eyer-go-colorful-fbed168999279944",
+        "relationshipType": "CONTAINS"
+      },
+      {
+        "spdxElementId": "SPDXRef-DocumentRoot-File-bomctl-0.3.0-darwin-arm64.tar.gz",
+        "relatedSpdxElement": "SPDXRef-Package-go-module-github.com-magiconair-properties-bb59395879b78628",
+        "relationshipType": "CONTAINS"
+      },
+      {
+        "spdxElementId": "SPDXRef-DocumentRoot-File-bomctl-0.3.0-darwin-arm64.tar.gz",
+        "relatedSpdxElement": "SPDXRef-Package-go-module-github.com-mattn-go-isatty-7e215fce8e704dd4",
+        "relationshipType": "CONTAINS"
+      },
+      {
+        "spdxElementId": "SPDXRef-DocumentRoot-File-bomctl-0.3.0-darwin-arm64.tar.gz",
+        "relatedSpdxElement": "SPDXRef-Package-go-module-github.com-mattn-go-runewidth-ce6e3b6b4e625eff",
+        "relationshipType": "CONTAINS"
+      },
+      {
+        "spdxElementId": "SPDXRef-DocumentRoot-File-bomctl-0.3.0-darwin-arm64.tar.gz",
+        "relatedSpdxElement": "SPDXRef-Package-go-module-github.com-mitchellh-go-wordwrap-9653b68335c34a14",
+        "relationshipType": "CONTAINS"
+      },
+      {
+        "spdxElementId": "SPDXRef-DocumentRoot-File-bomctl-0.3.0-darwin-arm64.tar.gz",
+        "relatedSpdxElement": "SPDXRef-Package-go-module-github.com-mitchellh-mapstructure-ce92bf8494f7c701",
+        "relationshipType": "CONTAINS"
+      },
+      {
+        "spdxElementId": "SPDXRef-DocumentRoot-File-bomctl-0.3.0-darwin-arm64.tar.gz",
+        "relatedSpdxElement": "SPDXRef-Package-go-module-github.com-muesli-termenv-cfc0e1203c415e26",
+        "relationshipType": "CONTAINS"
+      },
+      {
+        "spdxElementId": "SPDXRef-DocumentRoot-File-bomctl-0.3.0-darwin-arm64.tar.gz",
+        "relatedSpdxElement": "SPDXRef-Package-go-module-github.com-opencontainers-go-digest-acdedc5890713dd2",
+        "relationshipType": "CONTAINS"
+      },
+      {
+        "spdxElementId": "SPDXRef-DocumentRoot-File-bomctl-0.3.0-darwin-arm64.tar.gz",
+        "relatedSpdxElement": "SPDXRef-Package-go-module-github.com-opencontainers-image-spec-7d27d7681ca52fa3",
+        "relationshipType": "CONTAINS"
+      },
+      {
+        "spdxElementId": "SPDXRef-DocumentRoot-File-bomctl-0.3.0-darwin-arm64.tar.gz",
+        "relatedSpdxElement": "SPDXRef-Package-go-module-github.com-pelletier-go-toml-v2-0c4beda42b47b30f",
+        "relationshipType": "CONTAINS"
+      },
+      {
+        "spdxElementId": "SPDXRef-DocumentRoot-File-bomctl-0.3.0-darwin-arm64.tar.gz",
+        "relatedSpdxElement": "SPDXRef-Package-go-module-github.com-pjbgf-sha1cd-b19c6cb88557f8bd",
+        "relationshipType": "CONTAINS"
+      },
+      {
+        "spdxElementId": "SPDXRef-DocumentRoot-File-bomctl-0.3.0-darwin-arm64.tar.gz",
+        "relatedSpdxElement": "SPDXRef-Package-go-module-github.com-protobom-protobom-c6092a35d4046627",
+        "relationshipType": "CONTAINS"
+      },
+      {
+        "spdxElementId": "SPDXRef-DocumentRoot-File-bomctl-0.3.0-darwin-arm64.tar.gz",
+        "relatedSpdxElement": "SPDXRef-Package-go-module-github.com-protobom-storage-f53e9cde5f8d751c",
+        "relationshipType": "CONTAINS"
+      },
+      {
+        "spdxElementId": "SPDXRef-DocumentRoot-File-bomctl-0.3.0-darwin-arm64.tar.gz",
+        "relatedSpdxElement": "SPDXRef-Package-go-module-github.com-remyoudompheng-bigfft-af00bbfe7ea65ca7",
+        "relationshipType": "CONTAINS"
+      },
+      {
+        "spdxElementId": "SPDXRef-DocumentRoot-File-bomctl-0.3.0-darwin-arm64.tar.gz",
+        "relatedSpdxElement": "SPDXRef-Package-go-module-github.com-rivo-uniseg-6488b24fc2fd4ca4",
+        "relationshipType": "CONTAINS"
+      },
+      {
+        "spdxElementId": "SPDXRef-DocumentRoot-File-bomctl-0.3.0-darwin-arm64.tar.gz",
+        "relatedSpdxElement": "SPDXRef-Package-go-module-github.com-sagikazarmark-slog-shim-f8702e09f858dfb5",
+        "relationshipType": "CONTAINS"
+      },
+      {
+        "spdxElementId": "SPDXRef-DocumentRoot-File-bomctl-0.3.0-darwin-arm64.tar.gz",
+        "relatedSpdxElement": "SPDXRef-Package-go-module-github.com-sergi-go-diff-5f316aebeecf261b",
+        "relationshipType": "CONTAINS"
+      },
+      {
+        "spdxElementId": "SPDXRef-DocumentRoot-File-bomctl-0.3.0-darwin-arm64.tar.gz",
+        "relatedSpdxElement": "SPDXRef-Package-go-module-github.com-sirupsen-logrus-c9d8b46f2f6f848a",
+        "relationshipType": "CONTAINS"
+      },
+      {
+        "spdxElementId": "SPDXRef-DocumentRoot-File-bomctl-0.3.0-darwin-arm64.tar.gz",
+        "relatedSpdxElement": "SPDXRef-Package-go-module-github.com-skeema-knownhosts-8c3e08a98640688c",
+        "relationshipType": "CONTAINS"
+      },
+      {
+        "spdxElementId": "SPDXRef-DocumentRoot-File-bomctl-0.3.0-darwin-arm64.tar.gz",
+        "relatedSpdxElement": "SPDXRef-Package-go-module-github.com-spdx-tools-golang-4a08aad0b2bd69dc",
+        "relationshipType": "CONTAINS"
+      },
+      {
+        "spdxElementId": "SPDXRef-DocumentRoot-File-bomctl-0.3.0-darwin-arm64.tar.gz",
+        "relatedSpdxElement": "SPDXRef-Package-go-module-github.com-spf13-afero-5ec6bf38d7bbe47e",
+        "relationshipType": "CONTAINS"
+      },
+      {
+        "spdxElementId": "SPDXRef-DocumentRoot-File-bomctl-0.3.0-darwin-arm64.tar.gz",
+        "relatedSpdxElement": "SPDXRef-Package-go-module-github.com-spf13-cast-f6387b9a391d383c",
+        "relationshipType": "CONTAINS"
+      },
+      {
+        "spdxElementId": "SPDXRef-DocumentRoot-File-bomctl-0.3.0-darwin-arm64.tar.gz",
+        "relatedSpdxElement": "SPDXRef-Package-go-module-github.com-spf13-cobra-abc1a0131d6432f9",
+        "relationshipType": "CONTAINS"
+      },
+      {
+        "spdxElementId": "SPDXRef-DocumentRoot-File-bomctl-0.3.0-darwin-arm64.tar.gz",
+        "relatedSpdxElement": "SPDXRef-Package-go-module-github.com-spf13-pflag-0d74e9b919123713",
+        "relationshipType": "CONTAINS"
+      },
+      {
+        "spdxElementId": "SPDXRef-DocumentRoot-File-bomctl-0.3.0-darwin-arm64.tar.gz",
+        "relatedSpdxElement": "SPDXRef-Package-go-module-github.com-spf13-viper-ee2f520636d42a46",
+        "relationshipType": "CONTAINS"
+      },
+      {
+        "spdxElementId": "SPDXRef-DocumentRoot-File-bomctl-0.3.0-darwin-arm64.tar.gz",
+        "relatedSpdxElement": "SPDXRef-Package-go-module-github.com-subosito-gotenv-fcb83a5920e185c4",
+        "relationshipType": "CONTAINS"
+      },
+      {
+        "spdxElementId": "SPDXRef-DocumentRoot-File-bomctl-0.3.0-darwin-arm64.tar.gz",
+        "relatedSpdxElement": "SPDXRef-Package-go-module-github.com-xanzy-ssh-agent-fc817718385f3705",
+        "relationshipType": "CONTAINS"
+      },
+      {
+        "spdxElementId": "SPDXRef-DocumentRoot-File-bomctl-0.3.0-darwin-arm64.tar.gz",
+        "relatedSpdxElement": "SPDXRef-Package-go-module-github.com-zclconf-go-cty-5003adc9dafdd21d",
+        "relationshipType": "CONTAINS"
+      },
+      {
+        "spdxElementId": "SPDXRef-DocumentRoot-File-bomctl-0.3.0-darwin-arm64.tar.gz",
+        "relatedSpdxElement": "SPDXRef-Package-go-module-golang.org-x-crypto-cad8ee1f69d6ff20",
+        "relationshipType": "CONTAINS"
+      },
+      {
+        "spdxElementId": "SPDXRef-DocumentRoot-File-bomctl-0.3.0-darwin-arm64.tar.gz",
+        "relatedSpdxElement": "SPDXRef-Package-go-module-golang.org-x-mod-2ff257ab3ed63de6",
+        "relationshipType": "CONTAINS"
+      },
+      {
+        "spdxElementId": "SPDXRef-DocumentRoot-File-bomctl-0.3.0-darwin-arm64.tar.gz",
+        "relatedSpdxElement": "SPDXRef-Package-go-module-golang.org-x-net-61049d6178cf00bc",
+        "relationshipType": "CONTAINS"
+      },
+      {
+        "spdxElementId": "SPDXRef-DocumentRoot-File-bomctl-0.3.0-darwin-arm64.tar.gz",
+        "relatedSpdxElement": "SPDXRef-Package-go-module-golang.org-x-sync-f3affac3cfb945cc",
+        "relationshipType": "CONTAINS"
+      },
+      {
+        "spdxElementId": "SPDXRef-DocumentRoot-File-bomctl-0.3.0-darwin-arm64.tar.gz",
+        "relatedSpdxElement": "SPDXRef-Package-go-module-golang.org-x-sys-d48df6a309bf0b5a",
+        "relationshipType": "CONTAINS"
+      },
+      {
+        "spdxElementId": "SPDXRef-DocumentRoot-File-bomctl-0.3.0-darwin-arm64.tar.gz",
+        "relatedSpdxElement": "SPDXRef-Package-go-module-golang.org-x-text-0a267aadea95f8bc",
+        "relationshipType": "CONTAINS"
+      },
+      {
+        "spdxElementId": "SPDXRef-DocumentRoot-File-bomctl-0.3.0-darwin-arm64.tar.gz",
+        "relatedSpdxElement": "SPDXRef-Package-go-module-google.golang.org-protobuf-d430c7a0e4539ea4",
+        "relationshipType": "CONTAINS"
+      },
+      {
+        "spdxElementId": "SPDXRef-DocumentRoot-File-bomctl-0.3.0-darwin-arm64.tar.gz",
+        "relatedSpdxElement": "SPDXRef-Package-go-module-gopkg.in-ini.v1-d4dcf7d18233628d",
+        "relationshipType": "CONTAINS"
+      },
+      {
+        "spdxElementId": "SPDXRef-DocumentRoot-File-bomctl-0.3.0-darwin-arm64.tar.gz",
+        "relatedSpdxElement": "SPDXRef-Package-go-module-gopkg.in-warnings.v0-3054011fb8872ecd",
+        "relationshipType": "CONTAINS"
+      },
+      {
+        "spdxElementId": "SPDXRef-DocumentRoot-File-bomctl-0.3.0-darwin-arm64.tar.gz",
+        "relatedSpdxElement": "SPDXRef-Package-go-module-gopkg.in-yaml.v3-cb259ab751a0f22e",
+        "relationshipType": "CONTAINS"
+      },
+      {
+        "spdxElementId": "SPDXRef-DocumentRoot-File-bomctl-0.3.0-darwin-arm64.tar.gz",
+        "relatedSpdxElement": "SPDXRef-Package-go-module-modernc.org-libc-b7512b701a20d0b3",
+        "relationshipType": "CONTAINS"
+      },
+      {
+        "spdxElementId": "SPDXRef-DocumentRoot-File-bomctl-0.3.0-darwin-arm64.tar.gz",
+        "relatedSpdxElement": "SPDXRef-Package-go-module-modernc.org-mathutil-dcbd9a97ad7457a1",
+        "relationshipType": "CONTAINS"
+      },
+      {
+        "spdxElementId": "SPDXRef-DocumentRoot-File-bomctl-0.3.0-darwin-arm64.tar.gz",
+        "relatedSpdxElement": "SPDXRef-Package-go-module-modernc.org-memory-66ce26f959dea890",
+        "relationshipType": "CONTAINS"
+      },
+      {
+        "spdxElementId": "SPDXRef-DocumentRoot-File-bomctl-0.3.0-darwin-arm64.tar.gz",
+        "relatedSpdxElement": "SPDXRef-Package-go-module-modernc.org-sqlite-09e0d1c3ad5deb81",
+        "relationshipType": "CONTAINS"
+      },
+      {
+        "spdxElementId": "SPDXRef-DocumentRoot-File-bomctl-0.3.0-darwin-arm64.tar.gz",
+        "relatedSpdxElement": "SPDXRef-Package-go-module-oras.land-oras-go-v2-9b2a46aa5362acff",
+        "relationshipType": "CONTAINS"
+      },
+      {
+        "spdxElementId": "SPDXRef-DocumentRoot-File-bomctl-0.3.0-darwin-arm64.tar.gz",
+        "relatedSpdxElement": "SPDXRef-Package-go-module-sigs.k8s.io-release-utils-2930a4d6baa94c8d",
+        "relationshipType": "CONTAINS"
+      },
+      {
+        "spdxElementId": "SPDXRef-DocumentRoot-File-bomctl-0.3.0-darwin-arm64.tar.gz",
+        "relatedSpdxElement": "SPDXRef-Package-go-module-stdlib-f9d1785bc3385da5",
+        "relationshipType": "CONTAINS"
+      },
+      {
+        "spdxElementId": "SPDXRef-DOCUMENT",
+        "relatedSpdxElement": "SPDXRef-DocumentRoot-File-bomctl-0.3.0-darwin-arm64.tar.gz",
+        "relationshipType": "DESCRIBES"
+      }
+    ],
+    "comment": "bomctl is format-agnostic Software Bill of Materials (SBOM) tooling, which is intended to bridge the gap between SBOM generation and SBOM analysis tools. It focuses on supporting more complex SBOM operations by being opinionated on only supporting the NTIA minimum fields or other fields supported by protobom.",
+    "hasExtractedLicensingInfos": [
+      {
+        "name": "Apache License 2.0",
+        "licenseId": "LicenseRef-Apache-2.0",
+        "seeAlsos": [
+          "https://raw.githubusercontent.com/bomctl/bomctl/main/LICENSE"
+        ],
+        "extractedText": "                                 Apache License\n                           Version 2.0, January 2004\n                        http://www.apache.org/licenses/\n\n   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION\n\n   1. Definitions.\n\n      \"License\" shall mean the terms and conditions for use, reproduction,\n      and distribution as defined by Sections 1 through 9 of this document.\n\n      \"Licensor\" shall mean the copyright owner or entity authorized by\n      the copyright owner that is granting the License.\n\n      \"Legal Entity\" shall mean the union of the acting entity and all\n      other entities that control, are controlled by, or are under common\n      control with that entity. For the purposes of this definition,\n      \"control\" means (i) the power, direct or indirect, to cause the\n      direction or management of such entity, whether by contract or\n      otherwise, or (ii) ownership of fifty percent (50%) or more of the\n      outstanding shares, or (iii) beneficial ownership of such entity.\n\n      \"You\" (or \"Your\") shall mean an individual or Legal Entity\n      exercising permissions granted by this License.\n\n      \"Source\" form shall mean the preferred form for making modifications,\n      including but not limited to software source code, documentation\n      source, and configuration files.\n\n      \"Object\" form shall mean any form resulting from mechanical\n      transformation or translation of a Source form, including but\n      not limited to compiled object code, generated documentation,\n      and conversions to other media types.\n\n      \"Work\" shall mean the work of authorship, whether in Source or\n      Object form, made available under the License, as indicated by a\n      copyright notice that is included in or attached to the work\n      (an example is provided in the Appendix below).\n\n      \"Derivative Works\" shall mean any work, whether in Source or Object\n      form, that is based on (or derived from) the Work and for which the\n      editorial revisions, annotations, elaborations, or other modifications\n      represent, as a whole, an original work of authorship. For the purposes\n      of this License, Derivative Works shall not include works that remain\n      separable from, or merely link (or bind by name) to the interfaces of,\n      the Work and Derivative Works thereof.\n\n      \"Contribution\" shall mean any work of authorship, including\n      the original version of the Work and any modifications or additions\n      to that Work or Derivative Works thereof, that is intentionally\n      submitted to Licensor for inclusion in the Work by the copyright owner\n      or by an individual or Legal Entity authorized to submit on behalf of\n      the copyright owner. For the purposes of this definition, \"submitted\"\n      means any form of electronic, verbal, or written communication sent\n      to the Licensor or its representatives, including but not limited to\n      communication on electronic mailing lists, source code control systems,\n      and issue tracking systems that are managed by, or on behalf of, the\n      Licensor for the purpose of discussing and improving the Work, but\n      excluding communication that is conspicuously marked or otherwise\n      designated in writing by the copyright owner as \"Not a Contribution.\"\n\n      \"Contributor\" shall mean Licensor and any individual or Legal Entity\n      on behalf of whom a Contribution has been received by Licensor and\n      subsequently incorporated within the Work.\n\n   2. Grant of Copyright License. Subject to the terms and conditions of\n      this License, each Contributor hereby grants to You a perpetual,\n      worldwide, non-exclusive, no-charge, royalty-free, irrevocable\n      copyright license to reproduce, prepare Derivative Works of,\n      publicly display, publicly perform, sublicense, and distribute the\n      Work and such Derivative Works in Source or Object form.\n\n   3. Grant of Patent License. Subject to the terms and conditions of\n      this License, each Contributor hereby grants to You a perpetual,\n      worldwide, non-exclusive, no-charge, royalty-free, irrevocable\n      (except as stated in this section) patent license to make, have made,\n      use, offer to sell, sell, import, and otherwise transfer the Work,\n      where such license applies only to those patent claims licensable\n      by such Contributor that are necessarily infringed by their\n      Contribution(s) alone or by combination of their Contribution(s)\n      with the Work to which such Contribution(s) was submitted. If You\n      institute patent litigation against any entity (including a\n      cross-claim or counterclaim in a lawsuit) alleging that the Work\n      or a Contribution incorporated within the Work constitutes direct\n      or contributory patent infringement, then any patent licenses\n      granted to You under this License for that Work shall terminate\n      as of the date such litigation is filed.\n\n   4. Redistribution. You may reproduce and distribute copies of the\n      Work or Derivative Works thereof in any medium, with or without\n      modifications, and in Source or Object form, provided that You\n      meet the following conditions:\n\n      (a) You must give any other recipients of the Work or\n          Derivative Works a copy of this License; and\n\n      (b) You must cause any modified files to carry prominent notices\n          stating that You changed the files; and\n\n      (c) You must retain, in the Source form of any Derivative Works\n          that You distribute, all copyright, patent, trademark, and\n          attribution notices from the Source form of the Work,\n          excluding those notices that do not pertain to any part of\n          the Derivative Works; and\n\n      (d) If the Work includes a \"NOTICE\" text file as part of its\n          distribution, then any Derivative Works that You distribute must\n          include a readable copy of the attribution notices contained\n          within such NOTICE file, excluding those notices that do not\n          pertain to any part of the Derivative Works, in at least one\n          of the following places: within a NOTICE text file distributed\n          as part of the Derivative Works; within the Source form or\n          documentation, if provided along with the Derivative Works; or,\n          within a display generated by the Derivative Works, if and\n          wherever such third-party notices normally appear. The contents\n          of the NOTICE file are for informational purposes only and\n          do not modify the License. You may add Your own attribution\n          notices within Derivative Works that You distribute, alongside\n          or as an addendum to the NOTICE text from the Work, provided\n          that such additional attribution notices cannot be construed\n          as modifying the License.\n\n      You may add Your own copyright statement to Your modifications and\n      may provide additional or different license terms and conditions\n      for use, reproduction, or distribution of Your modifications, or\n      for any such Derivative Works as a whole, provided Your use,\n      reproduction, and distribution of the Work otherwise complies with\n      the conditions stated in this License.\n\n   5. Submission of Contributions. Unless You explicitly state otherwise,\n      any Contribution intentionally submitted for inclusion in the Work\n      by You to the Licensor shall be under the terms and conditions of\n      this License, without any additional terms or conditions.\n      Notwithstanding the above, nothing herein shall supersede or modify\n      the terms of any separate license agreement you may have executed\n      with Licensor regarding such Contributions.\n\n   6. Trademarks. This License does not grant permission to use the trade\n      names, trademarks, service marks, or product names of the Licensor,\n      except as required for reasonable and customary use in describing the\n      origin of the Work and reproducing the content of the NOTICE file.\n\n   7. Disclaimer of Warranty. Unless required by applicable law or\n      agreed to in writing, Licensor provides the Work (and each\n      Contributor provides its Contributions) on an \"AS IS\" BASIS,\n      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or\n      implied, including, without limitation, any warranties or conditions\n      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A\n      PARTICULAR PURPOSE. You are solely responsible for determining the\n      appropriateness of using or redistributing the Work and assume any\n      risks associated with Your exercise of permissions under this License.\n\n   8. Limitation of Liability. In no event and under no legal theory,\n      whether in tort (including negligence), contract, or otherwise,\n      unless required by applicable law (such as deliberate and grossly\n      negligent acts) or agreed to in writing, shall any Contributor be\n      liable to You for damages, including any direct, indirect, special,\n      incidental, or consequential damages of any character arising as a\n      result of this License or out of the use or inability to use the\n      Work (including but not limited to damages for loss of goodwill,\n      work stoppage, computer failure or malfunction, or any and all\n      other commercial damages or losses), even if such Contributor\n      has been advised of the possibility of such damages.\n\n   9. Accepting Warranty or Additional Liability. While redistributing\n      the Work or Derivative Works thereof, You may choose to offer,\n      and charge a fee for, acceptance of support, warranty, indemnity,\n      or other liability obligations and/or rights consistent with this\n      License. However, in accepting such obligations, You may act only\n      on Your own behalf and on Your sole responsibility, not on behalf\n      of any other Contributor, and only if You agree to indemnify,\n      defend, and hold each Contributor harmless for any liability\n      incurred by, or claims asserted against, such Contributor by reason\n      of your accepting any such warranty or additional liability.\n\n   END OF TERMS AND CONDITIONS\n\n   APPENDIX: How to apply the Apache License to your work.\n\n      To apply the Apache License to your work, attach the following\n      boilerplate notice, with the fields enclosed by brackets \"[]\"\n      replaced with your own identifying information. (Don't include\n      the brackets!)  The text should be enclosed in the appropriate\n      comment syntax for the file format. We also recommend that a\n      file or class name and description of purpose be included on the\n      same \"printed page\" as the copyright notice for easier\n      identification within third-party archives.\n\n   Copyright [yyyy] [name of copyright owner]\n\n   Licensed under the Apache License, Version 2.0 (the \"License\");\n   you may not use this file except in compliance with the License.\n   You may obtain a copy of the License at\n\n       http://www.apache.org/licenses/LICENSE-2.0\n\n   Unless required by applicable law or agreed to in writing, software\n   distributed under the License is distributed on an \"AS IS\" BASIS,\n   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.\n   See the License for the specific language governing permissions and\n   limitations under the License.\n"
+      }
+    ]
+  }

--- a/examples/bomctl_merge_A.cdx.json
+++ b/examples/bomctl_merge_A.cdx.json
@@ -1,0 +1,59 @@
+{
+    "$schema": "http://cyclonedx.org/schema/bom-1.5.schema.json",
+    "bomFormat": "CycloneDX",
+    "specVersion": "1.5",
+    "serialNumber": "urn:uuid:3de02d44-f9c6-4a94-bf48-eb92730dc3b5",
+    "version": 1,
+    "metadata": {
+        "timestamp": "2024-04-19T18:53:18Z",
+        "tools": {
+            "components": [
+                {
+                    "type": "application",
+                    "author": "anchore",
+                    "name": "syft",
+                    "version": "0.103.1"
+                }
+            ]
+        },
+        "component": {
+            "bom-ref": "802d09e3787af8a4",
+            "type": "file",
+            "name": "bomctl_0.1.1_darwin_arm64.tar.gz",
+            "version": "sha256:07aca4c7d757b18118b407733d90e8ae21fe8e95d191005451bb7a64a713fddc"
+        }
+    },
+    "components": [
+        {
+            "bom-ref": "pkg:golang/dario.cat/mergo@v1.0.0?package-id=f1f49cb0aea87079",
+            "type": "library",
+            "name": "dario.cat/mergo",
+            "version": "v1.0.0",
+            "purl": "pkg:golang/dario.cat/mergo@v1.0.0"
+        },
+        {
+            "bom-ref": "pkg:golang/github.com/cyclonedx/cyclonedx-go@v0.8.0?package-id=5d5b0319526af89b",
+            "type": "library",
+            "name": "github.com/CycloneDX/cyclonedx-go",
+            "version": "v0.8.0",
+            "cpe": "cpe:2.3:a:CycloneDX:cyclonedx-go:v0.8.0:*:*:*:*:*:*:*",
+            "purl": "pkg:golang/github.com/CycloneDX/cyclonedx-go@v0.8.0"
+        },
+        {
+            "bom-ref": "pkg:golang/github.com/pelletier/go-toml@v2.0.8?package-id=45e331af0112fd98#v2",
+            "type": "library",
+            "name": "github.com/pelletier/go-toml/v2",
+            "version": "v2.0.8",
+            "cpe": "cpe:2.3:a:pelletier:go-toml\\/v2:v2.0.8:*:*:*:*:*:*:*",
+            "purl": "pkg:golang/github.com/pelletier/go-toml@v2.0.8#v2"
+        },
+        {
+            "bom-ref": "pkg:golang/github.com/opencontainers/image-spec@v1.1.0?package-id=48f29ee7ac2ab2c0",
+            "type": "library",
+            "name": "github.com/opencontainers/image-spec",
+            "version": "v1.1.0",
+            "cpe": "cpe:2.3:a:opencontainers:image-spec:v1.1.0:*:*:*:*:*:*:*",
+            "purl": "pkg:golang/github.com/opencontainers/image-spec@v1.1.0"
+        }
+    ]
+}

--- a/examples/bomctl_merge_B.cdx.json
+++ b/examples/bomctl_merge_B.cdx.json
@@ -1,0 +1,59 @@
+{
+    "$schema": "http://cyclonedx.org/schema/bom-1.5.schema.json",
+    "bomFormat": "CycloneDX",
+    "specVersion": "1.5",
+    "serialNumber": "urn:uuid:0cd5c64f-318a-40cd-a2a9-a93301beff5d",
+    "version": 1,
+    "metadata": {
+        "timestamp": "2024-04-19T18:53:18Z",
+        "tools": {
+            "components": [
+                {
+                    "type": "application",
+                    "author": "anchore",
+                    "name": "syft",
+                    "version": "0.103.1"
+                }
+            ]
+        },
+        "component": {
+            "bom-ref": "802d09e3787af8a4",
+            "type": "file",
+            "name": "bomctl_0.1.1_darwin_arm64.tar.gz",
+            "version": "sha256:07aca4c7d757b18118b407733d90e8ae21fe8e95d191005451bb7a64a713fddc"
+        }
+    },
+    "components": [
+        {
+            "bom-ref": "pkg:golang/dario.cat/mergo@v0.9.0?package-id=f1f49cb0aea87079",
+            "type": "library",
+            "name": "dario.cat/mergo",
+            "version": "v0.9.0",
+            "purl": "pkg:golang/dario.cat/mergo@v0.9.0"
+        },
+        {
+            "bom-ref": "pkg:golang/github.com/cyclonedx/cyclonedx-go@v0.8.1?package-id=5d5b0319526af89b",
+            "type": "library",
+            "name": "github.com/CycloneDX/cyclonedx-go",
+            "version": "v0.8.1",
+            "cpe": "cpe:2.3:a:CycloneDX:cyclonedx-go:v0.8.1:*:*:*:*:*:*:*",
+            "purl": "pkg:golang/github.com/CycloneDX/cyclonedx-go@v0.8.1"
+        },
+        {
+            "bom-ref": "pkg:golang/github.com/pelletier/go-toml@v2?package-id=45e331af0112fd98#v2",
+            "type": "library",
+            "name": "github.com/pelletier/go-toml/v2",
+            "version": "v2",
+            "cpe": "cpe:2.3:a:pelletier:go-toml\\/v2:v2:*:*:*:*:*:*:*",
+            "purl": "pkg:golang/github.com/pelletier/go-toml@v2"
+        },
+        {
+            "bom-ref": "pkg:golang/github.com/opencontainers/image-spec@v1.1.7?package-id=48f29ee7ac2ab2c0",
+            "type": "library",
+            "name": "github.com/opencontainers/image-spec",
+            "version": "v1.1.7",
+            "cpe": "cpe:2.3:a:opencontainers:image-spec:v1.1.7:*:*:*:*:*:*:*",
+            "purl": "pkg:golang/github.com/opencontainers/image-spec@v1.1.7"
+        }
+    ]
+}


### PR DESCRIPTION
Updates Gitpod environment and exercises to match functionality releases in v0.4.0.

Additions:
- Trivy and grype added to the environment for showcasing import/export std in/out
- Section about format options and bomctl goal of being 'format agnostic'
- Added import from trivy example (spdx only, since no cdx 1.6 support)
- Added import frpm file example
- Added export to grype example
- Added export to file example
- Added Merge exercise section with related small sboms to illustrate functionality